### PR TITLE
docs: explicitly list example files in skill documentation

### DIFF
--- a/skills/bootstrap-components/SKILL.md
+++ b/skills/bootstrap-components/SKILL.md
@@ -1127,4 +1127,12 @@ tooltip.dispose();
 
 ---
 
-See `references/components-reference.md` for complete component API reference and `examples/` for component patterns.
+See `references/components-reference.md` for complete component API reference.
+
+For component implementation patterns, see:
+
+- `examples/carousel-patterns.html` - Carousel implementation patterns
+- `examples/modal-patterns.html` - Modal dialog patterns
+- `examples/navbar-patterns.html` - Navigation bar layouts
+- `examples/offcanvas-patterns.html` - Offcanvas sidebar patterns
+- `examples/tabs-patterns.html` - Tab navigation patterns

--- a/skills/bootstrap-content/SKILL.md
+++ b/skills/bootstrap-content/SKILL.md
@@ -289,4 +289,8 @@ Make a paragraph stand out:
 </table>
 ```
 
-See `references/typography-reference.md` for complete text utilities and `examples/` for content patterns.
+See `references/typography-reference.md` for complete text utilities.
+
+For content examples, see:
+
+- `examples/tables.html` - Table styling examples

--- a/skills/bootstrap-customize/SKILL.md
+++ b/skills/bootstrap-customize/SKILL.md
@@ -315,4 +315,9 @@ Use Bootstrap's mixins and functions for consistent components:
 // ... only import what you use
 ```
 
-See `references/sass-variables.md` for complete variable reference and `examples/` for theme examples.
+See `references/sass-variables.md` for complete variable reference.
+
+For customization examples, see:
+
+- `examples/color-mode-toggle.js` - Dark/light mode toggle implementation
+- `examples/custom-theme.scss` - Custom theme Sass file

--- a/skills/bootstrap-forms/SKILL.md
+++ b/skills/bootstrap-forms/SKILL.md
@@ -358,4 +358,8 @@ Bootstrap provides comprehensive form styling including controls, layouts, valid
 <div class="invalid-feedback">Please provide a valid value.</div>
 ```
 
-See `references/form-reference.md` for complete form class reference and `examples/` for form templates.
+See `references/form-reference.md` for complete form class reference.
+
+For form examples, see:
+
+- `examples/validation-form.html` - Form validation patterns

--- a/skills/bootstrap-layout/SKILL.md
+++ b/skills/bootstrap-layout/SKILL.md
@@ -325,4 +325,8 @@ Bootstrap 5.3 also supports CSS Grid:
 </div>
 ```
 
-See `references/grid-reference.md` for complete grid class reference and `examples/` for layout templates.
+See `references/grid-reference.md` for complete grid class reference.
+
+For layout examples, see:
+
+- `examples/responsive-layouts.html` - Responsive layout patterns


### PR DESCRIPTION
## Summary

- Updated 5 skill files to explicitly list their example files with descriptions
- Follows the established pattern from `bootstrap-overview/SKILL.md`
- Improves discoverability of example files for Claude Code users

## Problem

Fixes #9

Skills referenced their `examples/` directory generically (e.g., "See `examples/` for component patterns") but didn't list specific files, making example files harder to discover compared to `bootstrap-overview`, which explicitly names each file.

## Solution

Updated the "Additional Resources" section of each affected skill to explicitly list example files with descriptions:

| Skill | Example Files Added |
|-------|---------------------|
| bootstrap-components | `carousel-patterns.html`, `modal-patterns.html`, `navbar-patterns.html`, `offcanvas-patterns.html`, `tabs-patterns.html` |
| bootstrap-content | `tables.html` |
| bootstrap-customize | `color-mode-toggle.js`, `custom-theme.scss` |
| bootstrap-forms | `validation-form.html` |
| bootstrap-layout | `responsive-layouts.html` |

### Alternatives Considered

- **No change**: Would leave the discoverability issue unresolved
- **Auto-generated file lists**: More complex and could become stale; explicit listings are clearer

## Changes

- `skills/bootstrap-components/SKILL.md` - Added 5 example file listings
- `skills/bootstrap-content/SKILL.md` - Added 1 example file listing
- `skills/bootstrap-customize/SKILL.md` - Added 2 example file listings
- `skills/bootstrap-forms/SKILL.md` - Added 1 example file listing
- `skills/bootstrap-layout/SKILL.md` - Added 1 example file listing

## Testing

- [x] Markdownlint passes on all changed files
- [x] All listed example files exist and are correctly named
- [x] Pattern matches `bootstrap-overview/SKILL.md` style

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)