### PR TITLE
docs: create reboot-reference.md for detailed Reboot documentation

### DIFF
--- a/skills/bootstrap-content/SKILL.md
+++ b/skills/bootstrap-content/SKILL.md
@@ -262,6 +262,8 @@ Bootstrap Reboot normalizes default browser styles for consistent cross-browser 
 <p><abbr title="Cascading Style Sheets" class="initialism">CSS</abbr> for styling.</p>
 ```
 
+See `references/reboot-reference.md` for CSS variables, page defaults, native font stack, and Sass customization options.
+
 ## Images
 
 ### Responsive Images

--- a/skills/bootstrap-content/references/reboot-reference.md
+++ b/skills/bootstrap-content/references/reboot-reference.md
@@ -1,0 +1,417 @@
+# Reboot Reference
+
+Complete reference for Bootstrap 5.3 Reboot - the normalized baseline styles that provide cross-browser consistency.
+
+## CSS Variables
+
+Bootstrap Reboot sets CSS custom properties on the `:root` element:
+
+### Body Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `--bs-body-font-family` | Body font family | System font stack |
+| `--bs-body-font-size` | Body font size | `1rem` |
+| `--bs-body-font-weight` | Body font weight | `400` |
+| `--bs-body-line-height` | Body line height | `1.5` |
+| `--bs-body-color` | Body text color | `#212529` |
+| `--bs-body-bg` | Body background | `#fff` |
+
+### Emphasis Variables
+
+| Variable | Description | Light Mode | Dark Mode |
+|----------|-------------|------------|-----------|
+| `--bs-emphasis-color` | High emphasis text | `#000` | `#fff` |
+| `--bs-secondary-color` | Secondary text | `rgba(33, 37, 41, 0.75)` | `rgba(222, 226, 230, 0.75)` |
+| `--bs-tertiary-color` | Tertiary text | `rgba(33, 37, 41, 0.5)` | `rgba(222, 226, 230, 0.5)` |
+| `--bs-secondary-bg` | Secondary background | `#e9ecef` | `#343a40` |
+| `--bs-tertiary-bg` | Tertiary background | `#f8f9fa` | `#2b3035` |
+
+### Link Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `--bs-link-color` | Link color | `#0d6efd` |
+| `--bs-link-hover-color` | Link hover color | `#0a58ca` |
+| `--bs-link-decoration` | Link text decoration | `underline` |
+
+### Border Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `--bs-border-width` | Default border width | `1px` |
+| `--bs-border-style` | Default border style | `solid` |
+| `--bs-border-color` | Default border color | `#dee2e6` |
+| `--bs-border-radius` | Default border radius | `0.375rem` |
+
+## Page Defaults
+
+### Box Sizing
+
+Bootstrap sets `box-sizing: border-box` globally:
+
+```css
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+```
+
+### Root Font Size
+
+The `:root` element uses the browser default (typically 16px), enabling `rem` units:
+
+```css
+:root {
+  font-size: var(--bs-root-font-size);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  :root {
+    scroll-behavior: smooth;
+  }
+}
+```
+
+### Body Defaults
+
+```css
+body {
+  margin: 0;
+  font-family: var(--bs-body-font-family);
+  font-size: var(--bs-body-font-size);
+  font-weight: var(--bs-body-font-weight);
+  line-height: var(--bs-body-line-height);
+  color: var(--bs-body-color);
+  background-color: var(--bs-body-bg);
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+}
+```
+
+## Native Font Stack
+
+Bootstrap uses a "native font stack" for optimal text rendering on every device:
+
+```scss
+$font-family-sans-serif:
+  system-ui,
+  -apple-system,
+  "Segoe UI",
+  Roboto,
+  "Helvetica Neue",
+  "Noto Sans",
+  "Liberation Sans",
+  Arial,
+  sans-serif,
+  "Apple Color Emoji",
+  "Segoe UI Emoji",
+  "Segoe UI Symbol",
+  "Noto Color Emoji";
+
+$font-family-monospace:
+  SFMono-Regular,
+  Menlo,
+  Monaco,
+  Consolas,
+  "Liberation Mono",
+  "Courier New",
+  monospace;
+```
+
+**Benefits:**
+
+- Faster page load (no web font downloads)
+- Native look and feel on each OS
+- Proper emoji rendering across platforms
+- Optimal accessibility (users see familiar fonts)
+
+## Element Resets
+
+### Headings
+
+| Element | margin-top | margin-bottom | font-weight |
+|---------|------------|---------------|-------------|
+| `h1`-`h6` | `0` | `0.5rem` | `500` |
+
+### Paragraphs
+
+```css
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+```
+
+### Links
+
+```css
+a {
+  color: var(--bs-link-color);
+  text-decoration: underline;
+}
+
+a:hover {
+  color: var(--bs-link-hover-color);
+}
+
+a:not([href]):not([class]) {
+  color: inherit;
+  text-decoration: none;
+}
+```
+
+### Lists
+
+```css
+ol, ul {
+  padding-left: 2rem;
+}
+
+ol, ul, dl {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+ol ol, ul ul, ol ul, ul ol {
+  margin-bottom: 0;
+}
+
+dt {
+  font-weight: 700;
+}
+
+dd {
+  margin-bottom: 0.5rem;
+  margin-left: 0;
+}
+```
+
+### Blockquotes
+
+```css
+blockquote {
+  margin: 0 0 1rem;
+}
+```
+
+### Horizontal Rules
+
+```css
+hr {
+  margin: 1rem 0;
+  color: inherit;
+  border: 0;
+  border-top: var(--bs-border-width) solid;
+  opacity: 0.25;
+}
+```
+
+### Code Elements
+
+| Element | Font Family | Font Size |
+|---------|-------------|-----------|
+| `code` | Monospace stack | `0.875em` |
+| `kbd` | Monospace stack | `0.875em` |
+| `samp` | Monospace stack | `0.875em` |
+| `pre` | Monospace stack | `0.875em` |
+
+```css
+pre {
+  display: block;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  overflow: auto;
+  font-size: 0.875em;
+}
+
+code {
+  font-size: 0.875em;
+  color: var(--bs-code-color);
+  word-wrap: break-word;
+}
+```
+
+### Tables
+
+```css
+table {
+  caption-side: bottom;
+  border-collapse: collapse;
+}
+
+caption {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  color: var(--bs-secondary-color);
+  text-align: left;
+}
+
+th {
+  text-align: inherit;
+  text-align: -webkit-match-parent;
+}
+```
+
+### Forms
+
+```css
+label {
+  display: inline-block;
+}
+
+button {
+  border-radius: 0;
+}
+
+input, button, select, optgroup, textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+button, select {
+  text-transform: none;
+}
+
+fieldset {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+legend {
+  float: left;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 0.5rem;
+  font-size: calc(1.275rem + 0.3vw);
+  font-weight: inherit;
+  line-height: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+```
+
+### Images
+
+```css
+img, svg {
+  vertical-align: middle;
+}
+```
+
+### Summary
+
+```css
+summary {
+  display: list-item;
+  cursor: pointer;
+}
+```
+
+### Progress
+
+```css
+progress {
+  vertical-align: baseline;
+}
+```
+
+### Hidden Attribute
+
+```css
+[hidden] {
+  display: none !important;
+}
+```
+
+## Sass Variables
+
+Key Sass variables for customizing Reboot:
+
+### Typography
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$font-family-base` | `$font-family-sans-serif` | Base font family |
+| `$font-family-code` | `$font-family-monospace` | Code font family |
+| `$font-size-root` | `null` | Root font size |
+| `$font-size-base` | `1rem` | Base font size |
+| `$font-weight-base` | `400` | Base font weight |
+| `$line-height-base` | `1.5` | Base line height |
+
+### Body
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$body-bg` | `$white` | Body background color |
+| `$body-color` | `$gray-900` | Body text color |
+| `$body-emphasis-color` | `$black` | Emphasis text color |
+| `$body-secondary-color` | `rgba($body-color, .75)` | Secondary text |
+| `$body-tertiary-color` | `rgba($body-color, .5)` | Tertiary text |
+
+### Links
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$link-color` | `$primary` | Link color |
+| `$link-decoration` | `underline` | Link decoration |
+| `$link-hover-color` | `$link-color` shifted | Hover color |
+| `$link-hover-decoration` | `null` | Hover decoration |
+
+### Paragraphs
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$paragraph-margin-bottom` | `1rem` | Paragraph margin |
+
+### Horizontal Rules
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$hr-margin-y` | `1rem` | HR vertical margin |
+| `$hr-color` | `inherit` | HR color |
+| `$hr-border-color` | `null` | HR border color |
+| `$hr-border-width` | `var(--#{$prefix}border-width)` | HR border width |
+| `$hr-opacity` | `.25` | HR opacity |
+
+## Customization Examples
+
+### Custom Body Styling
+
+```scss
+// In your custom _variables.scss
+$body-bg: #f5f5f5;
+$body-color: #333;
+$font-family-base: "Helvetica Neue", Arial, sans-serif;
+$font-size-base: 1rem;
+$line-height-base: 1.6;
+```
+
+### Custom Link Styling
+
+```scss
+$link-color: #007bff;
+$link-decoration: none;
+$link-hover-color: darken($link-color, 15%);
+$link-hover-decoration: underline;
+```
+
+### Disable Reboot Features
+
+To prevent Reboot from affecting specific elements, override the CSS:
+
+```css
+/* Keep native list styling */
+ul.keep-native,
+ol.keep-native {
+  padding-left: revert;
+  margin: revert;
+}
+```


### PR DESCRIPTION
## Description

Create comprehensive reference documentation for Bootstrap's Reboot feature, providing deep-dive information that would be too verbose for SKILL.md but valuable for users who need to understand or customize Bootstrap's baseline styles.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README or skill docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Test (adding or updating tests)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [ ] Agent (`bootstrap-expert`)
- [ ] Commands (`/bootstrap-expert:component`)
- [ ] Examples (HTML/CSS/JS samples in `examples/` folders)
- [x] References (skill reference documents in `references/` folders)
- [ ] Documentation (README.md, CONTRIBUTING.md, SECURITY.md)
- [ ] Configuration (plugin.json, .markdownlint.json, .htmlhintrc, .yamllint.yml)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

Bootstrap's Reboot section contains detailed technical information about CSS variables, page defaults, native font stack, and element-specific resets. This information is valuable for developers customizing Bootstrap but too verbose for the main SKILL.md file.

Fixes #26

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Latest
- OS: macOS 26.1

**Test Steps**:

1. Ran `markdownlint 'skills/bootstrap-content/**/*.md'` - passed
2. Verified all CSS and Sass code examples are accurate
3. Cross-referenced with Bootstrap 5.3.8 official documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files
- [ ] I have run `uvx yamllint` on any YAML configuration files
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Bootstrap Icons references use version 1.13.x conventions
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [x] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl)

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Examples in `examples/` folder are valid HTML/CSS/JS
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

### Testing

- [ ] I have tested the plugin locally with `claude --plugin-dir .`
- [x] I have tested the full workflow (if applicable)
- [x] I have verified generated Bootstrap code renders correctly
- [ ] I have tested in a clean repository (not my development repo)

## Additional Notes

### reboot-reference.md Contents (~420 lines)

| Section | Description |
|---------|-------------|
| CSS Variables | Body, emphasis, link, and border variables with defaults |
| Page Defaults | Box-sizing, root font size, body defaults |
| Native Font Stack | System font stack with benefits explanation |
| Element Resets | Headings, paragraphs, links, lists, blockquotes, code, tables, forms, images |
| Sass Variables | Customization variables with defaults |
| Customization Examples | Practical examples for common customizations |

### Reference File Organization

The bootstrap-content skill now has 3 reference files:
- `typography-reference.md` - Text utilities and classes
- `tables-reference.md` - Table classes and patterns
- `reboot-reference.md` - CSS variables, page defaults, element resets

## Reviewer Notes

**Areas that need special attention**:
- Verify CSS variable values match Bootstrap 5.3.8 defaults
- Check that Sass variable names are accurate
- Ensure element reset CSS matches actual Bootstrap implementation

**Known limitations or trade-offs**:
- CSS values represent light mode defaults; dark mode values mentioned separately
- Some advanced Sass features not covered to keep reference focused

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)