### PR TITLE
docs: add component architecture patterns to bootstrap-customize skill

### DIFF
--- a/skills/bootstrap-customize/SKILL.md
+++ b/skills/bootstrap-customize/SKILL.md
@@ -295,6 +295,66 @@ $input-focus-border-color: tint-color($primary, 50%);
 $input-focus-box-shadow: 0 0 0 0.25rem rgba($primary, 0.25);
 ```
 
+## Component Architecture
+
+Bootstrap uses a **base-modifier pattern** for component styling. Understanding this architecture helps you customize existing components and create new ones that integrate seamlessly.
+
+### Base and Modifier Classes
+
+Components start with a base class providing core styling, then modifier classes add variants:
+
+```html
+<!-- Base class provides core styling -->
+<button class="btn">Base button</button>
+
+<!-- Modifier classes add variants -->
+<button class="btn btn-primary">Primary</button>
+<button class="btn btn-lg">Large</button>
+<button class="btn btn-primary btn-lg">Primary Large</button>
+```
+
+### Variant Generation with @each Loops
+
+Bootstrap generates color variants by iterating over `$theme-colors`:
+
+```scss
+// How Bootstrap generates .alert-primary, .alert-danger, etc.
+@each $state in map-keys($theme-colors) {
+  .alert-#{$state} {
+    --#{$prefix}alert-color: var(--#{$prefix}#{$state}-text-emphasis);
+    --#{$prefix}alert-bg: var(--#{$prefix}#{$state}-bg-subtle);
+    --#{$prefix}alert-border-color: var(--#{$prefix}#{$state}-border-subtle);
+  }
+}
+```
+
+**Key insight:** Adding a color to `$theme-colors` automatically generates variants for alerts, buttons, badges, list-groups, and more.
+
+### Custom Component with Variants
+
+Apply the same pattern for consistent custom components:
+
+```scss
+// Base class
+.callout {
+  padding: var(--bs-callout-padding, 1rem);
+  border-left: 4px solid var(--bs-callout-border-color, currentcolor);
+  background: var(--bs-callout-bg, transparent);
+}
+
+// Generate variants from theme colors
+@each $state, $value in $theme-colors {
+  .callout-#{$state} {
+    --bs-callout-border-color: var(--bs-#{$state});
+    --bs-callout-bg: var(--bs-#{$state}-bg-subtle);
+  }
+}
+```
+
+This generates `.callout-primary`, `.callout-danger`, etc., all inheriting from the base `.callout` styles.
+
+See `references/sass-functions-mixins.md` for `button-variant()` and other mixins that follow this pattern.
+
 ## Creating Custom Components
 
 Use Bootstrap's mixins and functions for consistent components:


### PR DESCRIPTION
## Description

Add a new "Component Architecture" section to the bootstrap-customize skill explaining Bootstrap's base-modifier pattern and @each loop variant generation.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

The bootstrap-customize skill showed basic component variable customization (buttons, cards, forms) but didn't explain Bootstrap's **base-modifier architecture** and the `@each` loop pattern used to generate component variants. This is crucial for users who want to:
- Add new theme colors and have them propagate to all components
- Create custom components that follow Bootstrap conventions
- Understand why modifying `$theme-colors` has cascading effects

Fixes #46

## How Has This Been Tested?

**Test Configuration**:

- OS: macOS
- markdownlint: Passed

**Test Steps**:

1. Ran `markdownlint 'skills/bootstrap-customize/SKILL.md'` - no errors
2. Verified section fits within skill's progressive disclosure pattern
3. Confirmed code examples match Bootstrap 5.3 documentation patterns

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Additional Notes

The new section covers:
1. **Base-modifier nomenclature** - How Bootstrap structures components with base classes (`.btn`) and modifier classes (`.btn-primary`, `.btn-lg`)
2. **@each loop variant generation** - How Bootstrap generates color variants by iterating over `$theme-colors`
3. **Custom component with variants** - A practical `.callout` example showing how to apply the same pattern

Reference: https://getbootstrap.com/docs/5.3/customize/components/

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)