### PR TITLE
docs: add required theme-colors keys warning to bootstrap-customize skill

### DIFF
--- a/skills/bootstrap-customize/SKILL.md
+++ b/skills/bootstrap-customize/SKILL.md
@@ -96,6 +96,12 @@ This generates all utilities: `.bg-custom`, `.text-brand`, `.btn-custom`, etc.
 $theme-colors: map-remove($theme-colors, "info", "light");
 ```
 
+> **Warning:** The `primary`, `success`, and `danger` keys are **required** and cannot be removed. They're used by Bootstrap's core styles for links, form validation, and other components. Removing them will cause Sass compilation errors.
+
+**Safe to remove:** `secondary`, `info`, `warning`, `light`, `dark`
+
+**Cannot remove:** `primary`, `success`, `danger`
+
 ## Color Modes (Dark/Light)
 
 Bootstrap 5.3 includes built-in dark mode support.


### PR DESCRIPTION
## Description

Add a warning to the "Removing Colors" section in the bootstrap-customize skill explaining that `primary`, `success`, and `danger` are required keys in `$theme-colors` that cannot be removed without causing Sass compilation errors.

Reference: https://getbootstrap.com/docs/5.3/customize/sass/#required-keys

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README or skill docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Test (adding or updating tests)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [ ] Agent (`bootstrap-expert`)
- [ ] Commands (`/bootstrap-expert:component`)
- [ ] Examples (HTML/CSS/JS samples in `examples/` folders)
- [ ] References (skill reference documents in `references/` folders)
- [ ] Documentation (README.md, CONTRIBUTING.md, SECURITY.md)
- [ ] Configuration (plugin.json, .markdownlint.json, .htmlhintrc, .yamllint.yml)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The existing "Removing Colors" section shows how to use `map-remove()` but doesn't warn that some keys are required. Users attempting to create minimal color palettes may encounter confusing Sass compilation errors when removing `primary`, `success`, or `danger`.

Fixes #47

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Latest
- OS: macOS

**Test Steps**:

1. Ran `markdownlint skills/bootstrap-customize/SKILL.md` - passes
2. Verified content matches official Bootstrap 5.3 documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files
- [ ] I have run `uvx yamllint` on any YAML configuration files
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [ ] Bootstrap Icons references use version 1.13.x conventions
- [ ] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [ ] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl)

### Accessibility

- [ ] Generated components include proper ARIA attributes where needed
- [ ] Color contrast considerations documented where relevant
- [ ] Keyboard navigation supported where applicable

### Testing

- [ ] I have tested the plugin locally with `claude --plugin-dir .`
- [ ] I have tested the full workflow (if applicable)
- [ ] I have verified generated Bootstrap code renders correctly
- [ ] I have tested in a clean repository (not my development repo)

### Version Management (if applicable)

- [ ] I have updated version in `.claude-plugin/plugin.json`
- [ ] I have updated CHANGELOG.md with relevant changes

## Additional Notes

This is a small documentation addition that prevents a common gotcha when customizing Bootstrap colors.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)