### PR TITLE
docs: add hover variants for link utilities in bootstrap-helpers

### DIFF
--- a/skills/bootstrap-helpers/SKILL.md
+++ b/skills/bootstrap-helpers/SKILL.md
@@ -64,6 +64,26 @@ Link colors with hover states:
 <a href="#" class="link-primary link-offset-3">More offset</a>
 ```
 
+### Hover Variants
+
+Link utilities include hover variants for dynamic effects:
+
+```html
+<!-- Opacity changes on hover -->
+<a href="#" class="link-primary link-opacity-50 link-opacity-100-hover">Brightens on hover</a>
+
+<!-- Underline appears on hover -->
+<a href="#" class="link-primary link-underline-opacity-0 link-underline-opacity-100-hover">Underline on hover</a>
+
+<!-- Offset changes on hover -->
+<a href="#" class="link-primary link-offset-2 link-offset-3-hover">Offset increases on hover</a>
+
+<!-- Combined hover effect -->
+<a href="#" class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">
+  Underline appears on hover
+</a>
+```
+
 ## Focus Ring
 
 Custom focus ring styling:

--- a/skills/bootstrap-helpers/references/helpers-reference.md
+++ b/skills/bootstrap-helpers/references/helpers-reference.md
@@ -44,6 +44,11 @@ Complete reference for Bootstrap 5.3 helper classes.
 | `.link-opacity-50` | 50% |
 | `.link-opacity-75` | 75% |
 | `.link-opacity-100` | 100% |
+| `.link-opacity-10-hover` | 10% on hover |
+| `.link-opacity-25-hover` | 25% on hover |
+| `.link-opacity-50-hover` | 50% on hover |
+| `.link-opacity-75-hover` | 75% on hover |
+| `.link-opacity-100-hover` | 100% on hover |
 
 ### Link Underline
 
@@ -57,6 +62,12 @@ Complete reference for Bootstrap 5.3 helper classes.
 | `.link-underline-opacity-50` | 50% underline opacity |
 | `.link-underline-opacity-75` | 75% underline opacity |
 | `.link-underline-opacity-100` | 100% underline opacity |
+| `.link-underline-opacity-0-hover` | No underline on hover |
+| `.link-underline-opacity-10-hover` | 10% underline opacity on hover |
+| `.link-underline-opacity-25-hover` | 25% underline opacity on hover |
+| `.link-underline-opacity-50-hover` | 50% underline opacity on hover |
+| `.link-underline-opacity-75-hover` | 75% underline opacity on hover |
+| `.link-underline-opacity-100-hover` | 100% underline opacity on hover |
 
 ### Link Offset
 
@@ -65,6 +76,9 @@ Complete reference for Bootstrap 5.3 helper classes.
 | `.link-offset-1` | 0.125em offset |
 | `.link-offset-2` | 0.25em offset |
 | `.link-offset-3` | 0.375em offset |
+| `.link-offset-1-hover` | 0.125em offset on hover |
+| `.link-offset-2-hover` | 0.25em offset on hover |
+| `.link-offset-3-hover` | 0.375em offset on hover |
 
 ## Focus Ring
 


### PR DESCRIPTION
## Description

Add missing hover variant classes for link utilities to the bootstrap-helpers skill documentation, aligning with the official Bootstrap 5.3 documentation.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The official Bootstrap 5.3 documentation includes hover variants for link utilities that were not documented in the bootstrap-helpers skill. These classes allow different visual effects on hover state.

Fixes #72

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Ran `markdownlint` on modified files - passed
2. Verified all added classes match Bootstrap 5.3 documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Additional Notes

### Changes Made

**SKILL.md:**
- Added new "Hover Variants" subsection under Colored Links with examples for:
  - Opacity changes on hover
  - Underline appears on hover
  - Offset changes on hover
  - Combined hover effects

**helpers-reference.md:**
- Added hover variant rows to Link Opacity table (5 classes)
- Added hover variant rows to Link Underline table (6 classes)
- Added hover variant rows to Link Offset table (3 classes)

### Classes Added

| Category | Classes |
|----------|---------|
| Link opacity | `.link-opacity-{10,25,50,75,100}-hover` |
| Link offset | `.link-offset-{1,2,3}-hover` |
| Underline opacity | `.link-underline-opacity-{0,10,25,50,75,100}-hover` |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)