### PR TITLE
docs: add missing CSS variables to bootstrap-helpers reference

### DIFF
--- a/skills/bootstrap-helpers/references/helpers-reference.md
+++ b/skills/bootstrap-helpers/references/helpers-reference.md
@@ -94,7 +94,16 @@ Complete reference for Bootstrap 5.3 helper classes.
 | `.focus-ring-light` | Light focus ring |
 | `.focus-ring-dark` | Dark focus ring |
 
-CSS variable: `--bs-focus-ring-color`
+### CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--bs-focus-ring-width` | `.25rem` | Ring width |
+| `--bs-focus-ring-opacity` | `.25` | Ring opacity |
+| `--bs-focus-ring-color` | `rgba(var(--bs-primary-rgb), var(--bs-focus-ring-opacity))` | Ring color |
+| `--bs-focus-ring-x` | `0` | Horizontal offset |
+| `--bs-focus-ring-y` | `0` | Vertical offset |
+| `--bs-focus-ring-blur` | `0` | Blur radius |
 
 ## Icon Link
 
@@ -103,7 +112,12 @@ CSS variable: `--bs-focus-ring-color`
 | `.icon-link` | Base icon link styling |
 | `.icon-link-hover` | Add hover animation |
 
-CSS variable: `--bs-icon-link-transform`
+### CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--bs-icon-link-transform` | `translate3d(.25em, 0, 0)` | Icon transform on hover |
+| `--bs-link-hover-color-rgb` | Varies by theme | Customize hover color |
 
 ## Position
 


### PR DESCRIPTION
## Description

Add complete CSS variable documentation for Focus Ring and Icon Link helpers in the bootstrap-helpers skill reference. This enables users to customize these helpers via CSS custom properties without needing to consult external documentation.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The `helpers-reference.md` file was incomplete compared to official Bootstrap documentation. Users customizing Focus Ring and Icon Link helpers via CSS variables couldn't find all available options in our documentation.

Fixes #73

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Latest
- OS: macOS

**Test Steps**:

1. Ran `markdownlint skills/bootstrap-helpers/references/helpers-reference.md` - passed
2. Verified CSS variable names and defaults match Bootstrap 5.3 documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation

## Additional Notes

Added CSS variables per Bootstrap 5.3 documentation:

**Focus Ring**:
- `--bs-focus-ring-width` (default: `.25rem`)
- `--bs-focus-ring-opacity` (default: `.25`)
- `--bs-focus-ring-color` (default: `rgba(var(--bs-primary-rgb), var(--bs-focus-ring-opacity))`)
- `--bs-focus-ring-x` (default: `0`)
- `--bs-focus-ring-y` (default: `0`)
- `--bs-focus-ring-blur` (default: `0`)

**Icon Link**:
- `--bs-icon-link-transform` (default: `translate3d(.25em, 0, 0)`)
- `--bs-link-hover-color-rgb` (varies by theme)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)