### PR TITLE
docs: add Sass mixins and variables for bootstrap-helpers customization

### DIFF
--- a/skills/bootstrap-helpers/SKILL.md
+++ b/skills/bootstrap-helpers/SKILL.md
@@ -313,9 +313,28 @@ Hide content visually but keep accessible to screen readers:
 ```
 
 **Use cases:**
+
 - Skip navigation links
 - Form labels when visual context is sufficient
 - Additional context for icons/images
 - Headings for document structure
 
-See `references/helpers-reference.md` for complete helper class reference.
+**Sass mixins** available for custom classes:
+
+```scss
+@import "bootstrap/scss/mixins/visually-hidden";
+
+.custom-sr-only {
+  @include visually-hidden;
+}
+```
+
+## Sass Customization
+
+Many helpers support build-time customization via Sass variables:
+
+- **Focus Ring**: `$focus-ring-width`, `$focus-ring-opacity`, `$focus-ring-blur`
+- **Icon Link**: `$icon-link-gap`, `$icon-link-icon-size`, `$icon-link-icon-transform`
+- **Ratio**: `$aspect-ratios` map for custom aspect ratios
+
+See `references/helpers-reference.md` for complete helper class reference and Sass customization options.

--- a/skills/bootstrap-helpers/references/helpers-reference.md
+++ b/skills/bootstrap-helpers/references/helpers-reference.md
@@ -236,3 +236,95 @@ Requires `display: block` or `display: inline-block` and fixed width.
   <button type="submit" class="btn btn-primary">Search</button>
 </form>
 ```
+
+## Sass Customization
+
+Bootstrap helpers can be customized at build time using Sass variables and mixins.
+
+### Visually Hidden Mixins
+
+Apply visually-hidden behavior to custom classes:
+
+```scss
+@import "bootstrap/scss/mixins/visually-hidden";
+
+.custom-sr-only {
+  @include visually-hidden;
+}
+
+.custom-skip-link {
+  @include visually-hidden-focusable;
+}
+```
+
+| Mixin | Description |
+|-------|-------------|
+| `visually-hidden` | Hide visually while keeping accessible to screen readers |
+| `visually-hidden-focusable` | Show element when focused (for skip links) |
+
+### Focus Ring Variables
+
+Customize default focus ring appearance before importing Bootstrap:
+
+```scss
+// Override defaults before importing Bootstrap
+$focus-ring-width: .5rem;
+$focus-ring-opacity: .5;
+$focus-ring-blur: 4px;
+
+@import "bootstrap/scss/bootstrap";
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$focus-ring-width` | `.25rem` | Ring width |
+| `$focus-ring-opacity` | `.25` | Ring opacity |
+| `$focus-ring-color` | `rgba($primary, $focus-ring-opacity)` | Ring color |
+| `$focus-ring-blur` | `0` | Blur radius |
+| `$focus-ring-box-shadow` | `0 0 $focus-ring-blur $focus-ring-width $focus-ring-color` | Complete box-shadow |
+
+### Icon Link Variables
+
+Adjust icon link defaults:
+
+```scss
+// Override defaults before importing Bootstrap
+$icon-link-gap: .5rem;
+$icon-link-icon-transform: translate3d(.5em, 0, 0);
+
+@import "bootstrap/scss/bootstrap";
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$icon-link-gap` | `.375rem` | Gap between icon and text |
+| `$icon-link-underline-offset` | `.25em` | Underline offset |
+| `$icon-link-icon-size` | `1em` | Icon size |
+| `$icon-link-icon-transition` | `.2s ease-in-out transform` | Hover animation timing |
+| `$icon-link-icon-transform` | `translate3d(.25em, 0, 0)` | Icon transform on hover |
+
+### Custom Aspect Ratios
+
+Add custom ratios via the Sass map:
+
+```scss
+// Extend the default aspect ratios
+$aspect-ratios: (
+  "1x1": 100%,
+  "4x3": calc(3 / 4 * 100%),
+  "16x9": calc(9 / 16 * 100%),
+  "21x9": calc(9 / 21 * 100%),
+  "3x2": calc(2 / 3 * 100%)  // Custom ratio
+);
+
+@import "bootstrap/scss/bootstrap";
+```
+
+| Ratio Key | Value | Result |
+|-----------|-------|--------|
+| `"1x1"` | `100%` | Square |
+| `"4x3"` | `calc(3 / 4 * 100%)` | 75% |
+| `"16x9"` | `calc(9 / 16 * 100%)` | 56.25% |
+| `"21x9"` | `calc(9 / 21 * 100%)` | 42.86% |
+
+Custom ratios generate classes like `.ratio-3x2` automatically.


### PR DESCRIPTION
## Description

Add comprehensive Sass customization documentation to the bootstrap-helpers skill, including mixins for visually hidden elements and variables for focus rings, icon links, and aspect ratios.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The bootstrap-helpers skill documented utility classes but lacked information about Sass mixins and variables that allow build-time customization. This is inconsistent with the bootstrap-customize skill which extensively covers Sass customization.

Fixes #74

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Latest
- OS: macOS

**Test Steps**:

1. Ran `markdownlint` on modified files - passed
2. Verified Sass code examples match Bootstrap 5.3.8 documentation
3. Confirmed variable names and default values are accurate

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files (N/A - no HTML changes)
- [ ] I have run `uvx yamllint` on any YAML configuration files (N/A - no YAML changes)
- [x] I have verified special HTML elements are properly closed

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Bootstrap Icons references use version 1.13.x conventions
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [x] Responsive breakpoints use correct Bootstrap values

### Accessibility

- [x] Generated components include proper ARIA attributes where needed
- [x] Color contrast considerations documented where relevant
- [x] Keyboard navigation supported where applicable

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Examples in `examples/` folder are valid HTML/CSS/JS
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Changes Made

### `skills/bootstrap-helpers/SKILL.md`
- Added Sass mixin example in Visually Hidden section
- Added new "Sass Customization" section summarizing available variables
- Updated reference link to mention Sass customization options

### `skills/bootstrap-helpers/references/helpers-reference.md`
- Added comprehensive "Sass Customization" section including:
  - Visually Hidden Mixins (`visually-hidden`, `visually-hidden-focusable`)
  - Focus Ring Variables (`$focus-ring-width`, `$focus-ring-opacity`, etc.)
  - Icon Link Variables (`$icon-link-gap`, `$icon-link-icon-size`, etc.)
  - Custom Aspect Ratios (`$aspect-ratios` Sass map)

## Reviewer Notes

**Areas that need special attention**:
- Verify Sass variable names and defaults match Bootstrap 5.3.8 source

**Known limitations or trade-offs**:
- None

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)