### PR TITLE
docs: add Safari browser support note for stacks gap utilities

### DIFF
--- a/skills/bootstrap-helpers/SKILL.md
+++ b/skills/bootstrap-helpers/SKILL.md
@@ -234,6 +234,8 @@ Quick flexbox layouts:
 </div>
 ```
 
+**Browser Support Note:** Gap utilities (`.gap-*`) with flexbox aren't fully supported in Safari versions prior to 14.5. Grid layout is unaffected. For broader browser support, consider using margin utilities instead.
+
 ## Stretched Link
 
 Make entire container clickable:

--- a/skills/bootstrap-helpers/references/helpers-reference.md
+++ b/skills/bootstrap-helpers/references/helpers-reference.md
@@ -161,6 +161,8 @@ CSS variable: `--bs-aspect-ratio`
 | `.hstack` | Horizontal stack (flex-row) |
 | `.gap-{0-5}` | Gap between items |
 
+⚠️ **Browser Support:** Gap with flexbox requires Safari 14.5+. Use margins or grid for older browser support.
+
 ## Stretched Link
 
 | Class | Description |


### PR DESCRIPTION
## Description

Add browser compatibility warning for `.gap-*` utilities with flexbox, noting that Safari 14.5+ is required for full support. This helps developers make informed decisions about browser support when using stack helpers.

Reference: https://getbootstrap.com/docs/5.3/helpers/stacks/

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README or skill docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Test (adding or updating tests)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [ ] Agent (`bootstrap-expert`)
- [ ] Commands (`/bootstrap-expert:component`)
- [ ] Examples (HTML/CSS/JS samples in `examples/` folders)
- [x] References (skill reference documents in `references/` folders)
- [ ] Documentation (README.md, CONTRIBUTING.md, SECURITY.md)
- [ ] Configuration (plugin.json, .markdownlint.json, .htmlhintrc, .yamllint.yml)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The official Bootstrap documentation includes a browser compatibility warning for stacks that was missing from the bootstrap-helpers skill. Safari 14.4 and earlier have incomplete `gap` support for flexbox, which can cause broken layouts. This note helps developers understand the limitation and provides alternatives (margin utilities or grid layout).

Fixes #75

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: N/A (documentation change)
- OS: macOS
- Browser(s) tested: N/A

**Test Steps**:

1. Ran `markdownlint` on both modified files - passed
2. Reviewed content matches issue requirements
3. Verified formatting consistency with existing documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files (N/A - no HTML changes)
- [ ] I have run `uvx yamllint` on any YAML configuration files (N/A - no YAML changes)
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Bootstrap Icons references use version 1.13.x conventions
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [x] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl)

### Accessibility

- [x] Generated components include proper ARIA attributes where needed
- [x] Color contrast considerations documented where relevant
- [x] Keyboard navigation supported where applicable

### Testing

- [ ] I have tested the plugin locally with `claude --plugin-dir .` (N/A - documentation only)
- [ ] I have tested the full workflow (if applicable) (N/A)
- [ ] I have verified generated Bootstrap code renders correctly (N/A)
- [ ] I have tested in a clean repository (not my development repo) (N/A)

### Version Management (if applicable)

- [ ] I have updated version in `.claude-plugin/plugin.json` (N/A - minor docs update)
- [ ] I have updated CHANGELOG.md with relevant changes (N/A - minor docs update)

## Additional Notes

Safari 14.5 was released in April 2021. While most users have updated, enterprise and institutional environments may still run older versions. The note provides helpful context without being overly alarming.

Can I Use reference for flexbox gap: https://caniuse.com/flexbox-gap

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)