### PR TITLE
docs: reference all example files in bootstrap-helpers skill

### DIFF
--- a/skills/bootstrap-helpers/SKILL.md
+++ b/skills/bootstrap-helpers/SKILL.md
@@ -350,6 +350,10 @@ Many helpers support build-time customization via Sass variables:
 
 For complete working examples, see:
 
-- `examples/stack-patterns.html` - Comprehensive vstack/hstack patterns including gap variations, nested layouts, and responsive alternatives
+- `examples/accessibility-patterns.html` - Visually hidden, focus ring, skip links, and screen reader utilities
+- `examples/link-helpers-patterns.html` - Colored links, icon links, stretched links, and link utilities
+- `examples/position-layout-patterns.html` - Fixed and sticky positioning patterns
+- `examples/ratio-embed-patterns.html` - Responsive video embeds and aspect ratio utilities
+- `examples/stack-patterns.html` - Comprehensive vstack/hstack patterns including gap variations
 
 See `references/helpers-reference.md` for complete helper class reference and Sass customization options.


### PR DESCRIPTION
## Summary

- Updates the Examples section in `bootstrap-helpers/SKILL.md` to reference all 5 example files
- Previously only `stack-patterns.html` was documented, leaving 4 example files undiscoverable
- Discovered during skill review against Claude Code plugin best practices

## Test plan

- [ ] Verify all 5 example file paths are correct
- [ ] Confirm descriptions accurately reflect each file's content

🤖 Generated with [Claude Code](https://claude.com/claude-code)