### PR TITLE
docs(bootstrap-icons): improve skill structure and progressive disclosure

### DIFF
--- a/skills/bootstrap-icons/SKILL.md
+++ b/skills/bootstrap-icons/SKILL.md
@@ -259,6 +259,46 @@ Include icons via CSS background-image or mask:
 </style>
 ```
 
+## Accessibility
+
+### Icons with Meaning
+
+When icons convey meaning, provide accessible text:
+
+```html
+<!-- Option 1: Visually hidden text -->
+<button class="btn btn-danger">
+  <i class="bi bi-trash" aria-hidden="true"></i>
+  <span class="visually-hidden">Delete</span>
+</button>
+
+<!-- Option 2: aria-label on parent -->
+<button class="btn btn-danger" aria-label="Delete">
+  <i class="bi bi-trash" aria-hidden="true"></i>
+</button>
+
+<!-- Option 3: title attribute (tooltip) -->
+<i class="bi bi-info-circle" title="More information" role="img" aria-label="More information"></i>
+```
+
+### Decorative Icons
+
+Hide purely decorative icons from screen readers:
+
+```html
+<i class="bi bi-star-fill" aria-hidden="true"></i>
+```
+
+### Icon with Visible Text
+
+When text is visible, hide icon from screen readers:
+
+```html
+<button class="btn btn-primary">
+  <i class="bi bi-download" aria-hidden="true"></i> Download
+</button>
+```
+
 ## Common Patterns
 
 ### Button with Icon
@@ -341,46 +381,6 @@ Include icons via CSS background-image or mask:
 </button>
 ```
 
-## Accessibility
-
-### Icons with Meaning
-
-When icons convey meaning, provide accessible text:
-
-```html
-<!-- Option 1: Visually hidden text -->
-<button class="btn btn-danger">
-  <i class="bi bi-trash" aria-hidden="true"></i>
-  <span class="visually-hidden">Delete</span>
-</button>
-
-<!-- Option 2: aria-label on parent -->
-<button class="btn btn-danger" aria-label="Delete">
-  <i class="bi bi-trash" aria-hidden="true"></i>
-</button>
-
-<!-- Option 3: title attribute (tooltip) -->
-<i class="bi bi-info-circle" title="More information" role="img" aria-label="More information"></i>
-```
-
-### Decorative Icons
-
-Hide purely decorative icons from screen readers:
-
-```html
-<i class="bi bi-star-fill" aria-hidden="true"></i>
-```
-
-### Icon with Visible Text
-
-When text is visible, hide icon from screen readers:
-
-```html
-<button class="btn btn-primary">
-  <i class="bi bi-download" aria-hidden="true"></i> Download
-</button>
-```
-
 ## Popular Icon Names
 
 ### Actions
@@ -412,6 +412,22 @@ When text is visible, hide icon from screen readers:
 ### Reference Files
 
 - **`references/icon-categories.md`** - Full icon list organized by category (Actions, Navigation, UI Elements, Status, Files, Media, Social, Devices, Weather, E-commerce, Development)
+
+**Quick category search patterns:**
+
+| Category | Search Pattern |
+|----------|----------------|
+| Actions | `grep "## Actions"` |
+| Navigation | `grep "## Navigation"` |
+| UI Elements | `grep "## UI Elements"` |
+| Status & Feedback | `grep "## Status"` |
+| Files & Folders | `grep "## Files"` |
+| Media Controls | `grep "## Media"` |
+| Social & Brands | `grep "## Social"` |
+| Devices | `grep "## Devices"` |
+| Weather | `grep "## Weather"` |
+| E-commerce | `grep "## E-commerce"` |
+| Development | `grep "## Development"` |
 
 ### Example Files
 


### PR DESCRIPTION
## Description

Improves the bootstrap-icons skill by aligning section ordering with official Bootstrap Icons documentation and adding search hints for progressive disclosure of the icon categories reference file.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

The current skill structure places "Common Patterns" before "Accessibility", which deviates from the official Bootstrap Icons documentation order. Additionally, the icon-categories reference file lacks search hints that would help Claude find relevant sections efficiently.

Fixes #101

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Latest
- OS: macOS

**Test Steps**:

1. Ran `markdownlint` on the modified SKILL.md - passes
2. Verified section ordering matches official Bootstrap Icons docs (Install → Usage → Styling → Accessibility → Patterns)
3. Verified search hint patterns match actual category headers in icon-categories.md

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Bootstrap Icons references use version 1.13.x conventions

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Additional Notes

**Changes made:**

1. **Section reordering**: Moved "Accessibility" section before "Common Patterns" to match official Bootstrap Icons documentation order
2. **Search hints added**: Added a table with grep patterns for all 11 icon categories in the Additional Resources section

The AI-specific sections (Common Patterns, Popular Icon Names) are retained but repositioned after the core documentation sections.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)