### PR TITLE
docs(bootstrap-icons): enhance skill description and clarify recommendations

### DIFF
--- a/skills/bootstrap-icons/SKILL.md
+++ b/skills/bootstrap-icons/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap-icons
-description: This skill should be used when the user asks about Bootstrap Icons, Bootstrap icon library, how to install Bootstrap Icons, how to use Bootstrap Icons, Bootstrap icon fonts, Bootstrap icon SVGs, Bootstrap icon sprites, Bootstrap Icons CDN, Bootstrap Icons npm, how to style Bootstrap icons, Bootstrap icon sizing, Bootstrap icon colors, Bootstrap icon accessibility, or needs help using icons in Bootstrap projects.
+description: This skill should be used when the user asks about Bootstrap Icons, Bootstrap icon library, how to install Bootstrap Icons, how to use Bootstrap Icons, Bootstrap icon fonts, Bootstrap icon SVGs, Bootstrap icon sprites, Bootstrap Icons CDN, Bootstrap Icons npm, Bootstrap Icons Composer, PHP Bootstrap Icons, Laravel icons, external image icons, img tag icons, CSS background icons, CSS mask icons, how to style Bootstrap icons, Bootstrap icon sizing, Bootstrap icon colors, Bootstrap icon accessibility, or needs help using icons in Bootstrap projects.
 ---
 
 # Bootstrap Icons
@@ -59,6 +59,15 @@ Then reference icons from the vendor directory:
 ## Usage Methods
 
 ### Icon Fonts (Recommended for Most Cases)
+
+Icon fonts are the simplest method for most projects:
+
+- **Easy syntax**: Just add `<i class="bi bi-*"></i>`
+- **Automatic sizing**: Icons scale with surrounding text
+- **Color inheritance**: Icons use the parent's `color` property
+- **Single dependency**: One CSS file provides all icons
+
+For advanced use cases (color gradients, animation, or offline/email), consider SVG methods instead.
 
 ```html
 <!-- Basic usage -->


### PR DESCRIPTION
## Description

Enhance the bootstrap-icons skill with improved discoverability and clearer documentation:

1. **Add missing trigger phrases** to YAML frontmatter description for better skill activation
2. **Explain the Icon Fonts recommendation** so users understand why it's the default choice

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

The skill description was missing trigger phrases for newer usage methods (External Image, CSS, Composer/PHP) that were added in previous PRs. Additionally, the "Recommended for Most Cases" label on Icon Fonts lacked explanation, which could leave users (and Claude) unclear on when to use this method vs alternatives.

Fixes #102

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Current
- OS: macOS

**Test Steps**:

1. Ran `markdownlint skills/bootstrap-icons/SKILL.md` - passed with no errors
2. Verified the YAML frontmatter syntax is valid
3. Confirmed added trigger phrases match the content added in #103 and #104

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files (N/A - no HTML changes)
- [ ] I have run `uvx yamllint` on any YAML configuration files (N/A - no YAML config changes)
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Bootstrap Icons references use version 1.13.x conventions
- [ ] Generated HTML/CSS uses valid Bootstrap 5.3.x classes (N/A - no HTML generated)
- [ ] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl) (N/A)

### Accessibility

- [ ] Generated components include proper ARIA attributes where needed (N/A)
- [ ] Color contrast considerations documented where relevant (N/A)
- [ ] Keyboard navigation supported where applicable (N/A)

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Examples in `examples/` folder are valid HTML/CSS/JS
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

### Testing

- [ ] I have tested the plugin locally with `claude --plugin-dir .`
- [ ] I have tested the full workflow (if applicable)
- [ ] I have verified generated Bootstrap code renders correctly (N/A)
- [ ] I have tested in a clean repository (not my development repo)

### Version Management (if applicable)

- [ ] I have updated version in `.claude-plugin/plugin.json` (N/A - minor doc update)
- [ ] I have updated CHANGELOG.md with relevant changes (N/A - minor doc update)

## Additional Notes

This PR completes the improvements suggested in issue #102, which was blocked by #99 and #100. Now that both dependencies are closed, all trigger phrases for the new content (External Image, CSS, Composer/PHP) can be added.

## Reviewer Notes

**Areas that need special attention**:
- Verify the new trigger phrases align with the content added in #103 and #104

**Known limitations or trade-offs**:
- None

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)