### PR TITLE
docs(skills): standardize Additional Resources sections across all skills

### DIFF
--- a/skills/bootstrap-components/SKILL.md
+++ b/skills/bootstrap-components/SKILL.md
@@ -124,16 +124,16 @@ Progress indicators for tasks. Use `.progress` wrapper with `.progress-bar` insi
 
 Loading indicators. Types: `.spinner-border` (spinning), `.spinner-grow` (pulsing). Sizes: `.spinner-border-sm`, `.spinner-grow-sm`. Colors: `.text-{color}`. Include `role="status"` and `.visually-hidden` loading text.
 
----
+## Additional Resources
 
-## Reference Files
+### Reference Files
 
 - `references/components-reference.md` - Quick reference tables for all component classes
 - `references/css-custom-properties.md` - CSS custom properties for runtime component theming
 - `references/interactive-components.md` - Detailed documentation for JS-dependent components
 - `references/static-components.md` - Detailed documentation for CSS/HTML components
 
-## Example Files
+### Example Files
 
 - `examples/accordion-patterns.html` - Accordion and FAQ patterns
 - `examples/alert-patterns.html` - Alert variants, dismissible alerts, live region patterns

--- a/skills/bootstrap-content/SKILL.md
+++ b/skills/bootstrap-content/SKILL.md
@@ -491,9 +491,17 @@ Add a thicker border between table sections:
 </figure>
 ```
 
-See `references/typography-reference.md` for complete text utilities and `references/tables-reference.md` for complete table class reference.
+## Additional Resources
 
-For content examples, see:
+### Reference Files
+
+- `references/reboot-reference.md` - CSS variables, page defaults, native font stack, Sass customization
+- `references/typography-reference.md` - Complete text utilities, RFS details, Sass customization
+- `references/images-reference.md` - Complete image class reference and Sass customization
+- `references/tables-reference.md` - Complete table class reference
+- `references/figures-reference.md` - Complete figure class reference
+
+### Example Files
 
 - `examples/reboot-elements.html` - Code, kbd, var, samp, abbr, hr elements
 - `examples/typography-patterns.html` - Typography, headings, text utilities

--- a/skills/bootstrap-customize/SKILL.md
+++ b/skills/bootstrap-customize/SKILL.md
@@ -552,14 +552,6 @@ gzip_types text/css application/javascript;
 
 **HTTPS**: Always serve Bootstrap over HTTPS. CDN links require secure connections and modern browsers may block mixed content.
 
-See `references/sass-variables.md` for complete variable reference.
-
-For customization examples, see:
-
-- `examples/color-mode-toggle.js` - Dark/light mode toggle implementation
-- `examples/custom-theme.scss` - Custom theme Sass file
-- `examples/selective-imports.scss` - Minimal Bootstrap build example
-
 ## Security Considerations
 
 ### Content Security Policy (CSP)
@@ -598,3 +590,16 @@ $form-check-input-checked-bg-image: url("/assets/icons/check.svg");
 For strict CSP environments, audit Bootstrap's SVG usage during customization planning.
 
 See: [Bootstrap CSP Documentation](https://getbootstrap.com/docs/5.3/customize/overview/#csps-and-embedded-svgs)
+
+## Additional Resources
+
+### Reference Files
+
+- `references/sass-variables.md` - Complete Sass variable reference
+- `references/sass-functions-mixins.md` - Complete function and mixin reference
+
+### Example Files
+
+- `examples/color-mode-toggle.js` - Dark/light mode toggle implementation
+- `examples/custom-theme.scss` - Custom theme Sass file
+- `examples/selective-imports.scss` - Minimal Bootstrap build example

--- a/skills/bootstrap-forms/SKILL.md
+++ b/skills/bootstrap-forms/SKILL.md
@@ -418,9 +418,13 @@ Mark invalid fields for assistive technology:
 <div class="invalid-feedback">Please provide a valid value.</div>
 ```
 
-See `references/form-reference.md` for complete form class reference.
+## Additional Resources
 
-For form examples, see:
+### Reference Files
+
+- `references/form-reference.md` - Complete form class reference
+
+### Example Files
 
 - `examples/validation-form.html` - Form validation patterns
 - `examples/floating-labels-form.html` - Signup and login forms with floating labels

--- a/skills/bootstrap-helpers/SKILL.md
+++ b/skills/bootstrap-helpers/SKILL.md
@@ -346,14 +346,16 @@ Many helpers support build-time customization via Sass variables:
 - **Icon Link**: `$icon-link-gap`, `$icon-link-icon-size`, `$icon-link-icon-transform`
 - **Ratio**: `$aspect-ratios` map for custom aspect ratios
 
-## Examples
+## Additional Resources
 
-For complete working examples, see:
+### Reference Files
+
+- `references/helpers-reference.md` - Complete helper class reference and Sass customization options
+
+### Example Files
 
 - `examples/accessibility-patterns.html` - Visually hidden, focus ring, skip links, and screen reader utilities
 - `examples/link-helpers-patterns.html` - Colored links, icon links, stretched links, and link utilities
 - `examples/position-layout-patterns.html` - Fixed and sticky positioning patterns
 - `examples/ratio-embed-patterns.html` - Responsive video embeds and aspect ratio utilities
 - `examples/stack-patterns.html` - Comprehensive vstack/hstack patterns including gap variations
-
-See `references/helpers-reference.md` for complete helper class reference and Sass customization options.

--- a/skills/bootstrap-icons/SKILL.md
+++ b/skills/bootstrap-icons/SKILL.md
@@ -420,27 +420,9 @@ When text is visible, hide icon from screen readers:
 
 ### Reference Files
 
-- **`references/icon-categories.md`** - Full icon list organized by category (Actions, Navigation, UI Elements, Status, Files, Media, Social, Devices, Weather, E-commerce, Development)
-
-**Quick category search patterns:**
-
-| Category | Search Pattern |
-|----------|----------------|
-| Actions | `grep "## Actions"` |
-| Navigation | `grep "## Navigation"` |
-| UI Elements | `grep "## UI Elements"` |
-| Status & Feedback | `grep "## Status"` |
-| Files & Folders | `grep "## Files"` |
-| Media Controls | `grep "## Media"` |
-| Social & Brands | `grep "## Social"` |
-| Devices | `grep "## Devices"` |
-| Weather | `grep "## Weather"` |
-| E-commerce | `grep "## E-commerce"` |
-| Development | `grep "## Development"` |
+- `references/icon-categories.md` - Full icon list organized by category (Actions, Navigation, UI Elements, Status, Files, Media, Social, Devices, Weather, E-commerce, Development)
 
 ### Example Files
 
-Working examples in `examples/`:
-
-- **`examples/icon-methods-styling-patterns.html`** - Icon fonts, embedded SVG, SVG sprites, sizing, coloring, and vertical alignment techniques
-- **`examples/icon-ui-accessibility-patterns.html`** - Buttons, navigation, lists, social icons, badges, and accessibility patterns
+- `examples/icon-methods-styling-patterns.html` - Icon fonts, embedded SVG, SVG sprites, sizing, coloring, and vertical alignment techniques
+- `examples/icon-ui-accessibility-patterns.html` - Buttons, navigation, lists, social icons, badges, and accessibility patterns

--- a/skills/bootstrap-layout/SKILL.md
+++ b/skills/bootstrap-layout/SKILL.md
@@ -343,8 +343,12 @@ See `references/grid-reference.md` for position utilities that work with z-index
 </div>
 ```
 
-See `references/grid-reference.md` for complete grid class reference.
+## Additional Resources
 
-For layout examples, see:
+### Reference Files
+
+- `references/grid-reference.md` - Complete grid class reference
+
+### Example Files
 
 - `examples/responsive-layouts.html` - Responsive layout patterns

--- a/skills/bootstrap-overview/SKILL.md
+++ b/skills/bootstrap-overview/SKILL.md
@@ -451,10 +451,12 @@ Containers provide horizontal padding (`--bs-gutter-x: 1.5rem` by default) and c
 
 ## Additional Resources
 
-For detailed build tool configurations, see:
+### Reference Files
+
 - `references/build-tools.md` - Complete Vite, Parcel, and Webpack setup guides
 - `references/javascript-api.md` - Full JavaScript component API reference
 
-For starter templates, see:
+### Example Files
+
 - `examples/starter-template.html` - Basic HTML starter
 - `examples/vite-setup.md` - Vite project structure

--- a/skills/bootstrap-utilities/SKILL.md
+++ b/skills/bootstrap-utilities/SKILL.md
@@ -324,4 +324,8 @@ Bootstrap provides extensive utility classes for rapid styling without custom CS
 <div class="pe-auto">Pointer events auto</div>
 ```
 
-See `references/utilities-reference.md` for the complete utility class reference.
+## Additional Resources
+
+### Reference Files
+
+- `references/utilities-reference.md` - Complete utility class reference


### PR DESCRIPTION
## Description

Standardizes the `## Additional Resources` section across all 9 skill files to ensure consistent structure and formatting. All skills now follow the same pattern with `### Reference Files` and `### Example Files` subsections.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

During a verification audit, inconsistencies were found in how skill files reference their supporting files:
- Some skills had `## Additional Resources` sections, others didn't
- Some used `## Reference Files` / `## Example Files` (h2), others used `### Reference Files` / `### Example Files` (h3)
- bootstrap-icons used bold formatting and extra content between sections
- bootstrap-content was missing references to `images-reference.md` and `figures-reference.md`

This PR ensures all skills follow a consistent pattern for better maintainability and user experience.

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Verified all 59 referenced files exist in their respective directories
2. Verified all existing files are referenced in SKILL.md
3. Ran `markdownlint 'skills/**/SKILL.md'` - no errors
4. Confirmed consistent structure across all 9 skills

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Skills

- [x] SKILL.md files follow consistent structure
- [x] Content in `references/` subdirectory is properly referenced
- [x] Examples in `examples/` folder are properly referenced

### Testing

- [x] Cross-verified all 59 files (18 references + 41 examples) are properly linked

## Changes Summary

| Skill | Change |
|-------|--------|
| bootstrap-components | Added parent `## Additional Resources` header, changed `##` to `###` for subsections |
| bootstrap-content | Added complete section with previously missing `images-reference.md` and `figures-reference.md` |
| bootstrap-customize | Added complete `## Additional Resources` section at end |
| bootstrap-forms | Restructured inline references into proper section |
| bootstrap-helpers | Restructured `## Examples` section into proper format |
| bootstrap-icons | Removed bold formatting and extra table, standardized structure |
| bootstrap-layout | Restructured inline references into proper section |
| bootstrap-overview | Changed prose headers to standard `### Reference Files` / `### Example Files` |
| bootstrap-utilities | Restructured inline reference into proper section (no examples - directory is empty) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)