### PR TITLE
docs(bootstrap-overview): refine content organization for progressive disclosure

### DIFF
--- a/skills/bootstrap-overview/SKILL.md
+++ b/skills/bootstrap-overview/SKILL.md
@@ -98,18 +98,7 @@ Create `src/scss/styles.scss`:
 @import "bootstrap/scss/bootstrap";
 ```
 
-### Parcel Setup
-
-```bash
-mkdir my-project && cd my-project
-npm init -y
-npm install bootstrap @popperjs/core
-npm install -D parcel sass
-```
-
-### Webpack Setup
-
-See `references/build-tools.md` for complete Webpack configuration.
+See `references/build-tools.md` for Parcel and Webpack setup guides.
 
 ## JavaScript Components
 
@@ -151,29 +140,7 @@ All components follow consistent patterns:
 - `dispose()` - Destroy instance and clean up
 - Component-specific methods (show, hide, toggle, etc.)
 
-### JavaScript Events
-
-Bootstrap components emit custom events at key moments in their lifecycle:
-
-```javascript
-const myModal = document.getElementById('myModal');
-
-// Listen for show event (before animation starts)
-myModal.addEventListener('show.bs.modal', event => {
-  // Prevent modal from opening if needed
-  if (someCondition) {
-    event.preventDefault();
-  }
-});
-
-// Listen for shown event (after animation completes)
-myModal.addEventListener('shown.bs.modal', event => {
-  // Focus an input or perform other actions
-  document.getElementById('myInput').focus();
-});
-```
-
-Events follow consistent naming: `{action}.bs.{component}` for before transitions and `{action}ed.bs.{component}` for after. Common pairs include `show`/`shown`, `hide`/`hidden`, `slide`/`slid`.
+See `references/javascript-api.md` for the complete JavaScript API including events, methods, and options for all components.
 
 ## Accessibility
 
@@ -414,6 +381,17 @@ node_modules/bootstrap/
     ├── _variables.scss
     └── ...
 ```
+
+**Available CSS builds:**
+
+| File | Contents |
+|------|----------|
+| `bootstrap.css` | Complete framework (default) |
+| `bootstrap-grid.css` | Grid system and flex utilities only |
+| `bootstrap-utilities.css` | Utility classes only |
+| `bootstrap-reboot.css` | Reboot normalization only |
+
+Each variant is available in `.min.css` (minified) and `.rtl.css` (right-to-left) versions.
 
 ## Key Concepts
 


### PR DESCRIPTION
## Description

Refines the bootstrap-overview skill content organization to improve progressive disclosure, reducing duplication with reference files while adding missing CSS build variants documentation.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

Identified during `/skill-review bootstrap-overview` against official Bootstrap 5.3 Getting Started documentation. The skill was well-crafted but had opportunities to improve content organization following progressive disclosure best practices.

Fixes #122

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Latest
- OS: macOS

**Test Steps**:

1. Ran `markdownlint skills/bootstrap-overview/SKILL.md` - passes with no errors
2. Verified word count (1,576 words) is within 1,000-2,200 range
3. Confirmed references to `references/javascript-api.md` and `references/build-tools.md` point to existing files
4. Verified CSS builds table information is accurate per Bootstrap documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Content aligns with official Bootstrap documentation

</details>

## Additional Notes

### Changes Made

1. **Removed JavaScript Events section** (lines 154-177) - Content was already covered in `references/javascript-api.md`. Replaced with single-line reference callout.

2. **Streamlined Build Tool Integration** (lines 101-112) - Removed Parcel Setup snippet and consolidated with Webpack into single reference callout pointing to `references/build-tools.md`. Kept Vite as the recommended tool with full example.

3. **Added CSS build variants table** to File Structure section - Documents `bootstrap-grid.css`, `bootstrap-utilities.css`, and `bootstrap-reboot.css` variants that were missing.

### Impact

- Word count: 1,618 → 1,576 (-42 words) while adding new CSS variants content
- Net reduction of 22 lines in SKILL.md
- Improved progressive disclosure (overview in SKILL.md → details in references/)

## Reviewer Notes

**Areas that need special attention**:
- Verify the CSS build variants table is accurate and complete
- Confirm the reference callouts are clear enough for users to find detailed content

**Known limitations or trade-offs**:
- Removing inline code examples trades immediate visibility for reduced duplication. Users must now consult reference files for Parcel/Webpack setup and JavaScript events details.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)