### PR TITLE
docs(bootstrap-utilities): complete Utilities API documentation

### DIFF
--- a/skills/bootstrap-utilities/SKILL.md
+++ b/skills/bootstrap-utilities/SKILL.md
@@ -459,6 +459,12 @@ Each utility is defined as a map with these key options:
 | `print` | Generate print variants (default: false) |
 | `state` | Generate state variants like `:hover` |
 | `css-var` | Output as CSS variables instead of rules |
+| `css-variable-name` | Custom CSS variable name (with css-var) |
+| `local-vars` | Map of local CSS variables |
+| `rfs` | Enable fluid rescaling (default: false) |
+| `rtl` | Include in RTL output (default: true) |
+
+**Note**: All utilities include `!important` by default. Disable globally with `$enable-important-utilities: false`.
 
 ### Adding Custom Utilities
 


### PR DESCRIPTION
## Description

Complete the Utilities API documentation in the bootstrap-utilities skill by adding missing API options and the `!important` behavior note, as identified in issue #128.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

The Utilities API section was missing several options from the official Bootstrap 5.3 documentation:
- `css-variable-name`: Custom CSS variable name (used with `css-var: true`)
- `local-vars`: Map of local CSS variables to generate
- `rfs`: Enable fluid rescaling with RFS (default: false)
- `rtl`: Include utility in RTL output (default: true)

Additionally, the important behavior of `!important` on all utilities (controllable via `$enable-important-utilities`) was not documented.

Fixes #128

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Ran `markdownlint skills/bootstrap-utilities/SKILL.md` - passes
2. Verified content matches official Bootstrap 5.3 Utilities API documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation

## Additional Notes

Changes verified against: https://getbootstrap.com/docs/5.3/utilities/api/

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)