### PR TITLE
docs(bootstrap-utilities): add float, vertical-align, link utilities

### DIFF
--- a/skills/bootstrap-utilities/SKILL.md
+++ b/skills/bootstrap-utilities/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap-utilities
-description: This skill should be used when the user asks about Bootstrap utilities, Bootstrap spacing utilities, Bootstrap margin utilities, Bootstrap padding utilities, Bootstrap display utilities, Bootstrap flex utilities, Bootstrap text utilities, Bootstrap color utilities, Bootstrap background utilities, Bootstrap border utilities, Bootstrap shadow utilities, Bootstrap sizing utilities, Bootstrap position utilities, Bootstrap visibility utilities, Bootstrap overflow utilities, Bootstrap opacity utilities, or needs help with Bootstrap utility classes.
+description: This skill should be used when the user asks about Bootstrap utilities, Bootstrap spacing utilities, Bootstrap margin utilities, Bootstrap padding utilities, Bootstrap display utilities, Bootstrap flex utilities, Bootstrap text utilities, Bootstrap color utilities, Bootstrap background utilities, Bootstrap border utilities, Bootstrap shadow utilities, Bootstrap sizing utilities, Bootstrap position utilities, Bootstrap visibility utilities, Bootstrap overflow utilities, Bootstrap opacity utilities, Bootstrap float utilities, Bootstrap vertical align utilities, Bootstrap link utilities, or needs help with Bootstrap utility classes.
 ---
 
 # Bootstrap 5.3 Utilities
@@ -464,6 +464,99 @@ Bootstrap provides extensive utility classes for rapid styling without custom CS
 <div class="pe-none">Pointer events none</div>
 <div class="pe-auto">Pointer events auto</div>
 ```
+
+## Float Utilities
+
+Float utilities position elements to the left or right of their container, allowing text to wrap around them.
+
+```html
+<div class="float-start">Float start (left in LTR)</div>
+<div class="float-end">Float end (right in LTR)</div>
+<div class="float-none">No float</div>
+
+<!-- Responsive floats -->
+<div class="float-sm-start">Float start on sm+</div>
+<div class="float-md-end">Float end on md+</div>
+<div class="float-lg-none">No float on lg+</div>
+```
+
+| Class | Description |
+|-------|-------------|
+| `float-start` | Float left (LTR) |
+| `float-end` | Float right (LTR) |
+| `float-none` | Remove float |
+
+Responsive: `float-{breakpoint}-{start|end|none}`
+
+**Note**: Modern layouts typically use flexbox or grid instead of floats. Floats remain useful for wrapping text around images.
+
+## Vertical Align Utilities
+
+Control vertical alignment of inline, inline-block, inline-table, and table cell elements.
+
+```html
+<span class="align-baseline">baseline</span>
+<span class="align-top">top</span>
+<span class="align-middle">middle</span>
+<span class="align-bottom">bottom</span>
+<span class="align-text-top">text-top</span>
+<span class="align-text-bottom">text-bottom</span>
+```
+
+| Class | Alignment |
+|-------|-----------|
+| `align-baseline` | Baseline (default) |
+| `align-top` | Top of line |
+| `align-middle` | Middle of line |
+| `align-bottom` | Bottom of line |
+| `align-text-top` | Top of parent's font |
+| `align-text-bottom` | Bottom of parent's font |
+
+**Note**: These work on inline/inline-block elements and table cells, not block elements. For block vertical alignment, use flexbox (`align-items-*`).
+
+## Link Utilities
+
+Style links with opacity, underline color, offset, and hover effects. Added in Bootstrap 5.3.
+
+```html
+<!-- Link opacity -->
+<a href="#" class="link-opacity-10">10% opacity</a>
+<a href="#" class="link-opacity-25">25% opacity</a>
+<a href="#" class="link-opacity-50">50% opacity</a>
+<a href="#" class="link-opacity-75">75% opacity</a>
+<a href="#" class="link-opacity-100">100% opacity</a>
+
+<!-- Hover opacity -->
+<a href="#" class="link-opacity-50-hover">50% on hover</a>
+
+<!-- Underline color -->
+<a href="#" class="link-underline-primary">Primary underline</a>
+<a href="#" class="link-underline-secondary">Secondary underline</a>
+<a href="#" class="link-underline-success">Success underline</a>
+
+<!-- Underline offset -->
+<a href="#" class="link-offset-1">1 offset</a>
+<a href="#" class="link-offset-2">2 offset</a>
+<a href="#" class="link-offset-3">3 offset</a>
+
+<!-- Underline opacity -->
+<a href="#" class="link-underline-opacity-0">No underline</a>
+<a href="#" class="link-underline-opacity-25">25% underline</a>
+<a href="#" class="link-underline-opacity-50">50% underline</a>
+
+<!-- Combined styling -->
+<a href="#" class="link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">
+  Styled link
+</a>
+```
+
+| Class | Description |
+|-------|-------------|
+| `link-opacity-{10\|25\|50\|75\|100}` | Link text opacity |
+| `link-opacity-{value}-hover` | Opacity on hover |
+| `link-underline-{color}` | Underline color |
+| `link-offset-{1\|2\|3}` | Underline distance |
+| `link-underline-opacity-{0\|10\|25\|50\|75\|100}` | Underline opacity |
 
 ## Utilities API
 

--- a/skills/bootstrap-utilities/references/utilities-reference.md
+++ b/skills/bootstrap-utilities/references/utilities-reference.md
@@ -379,3 +379,61 @@ primary, secondary, success, danger, warning, info, light, dark, black, white
 | `user-select-none` | No select |
 | `pe-none` | No pointer events |
 | `pe-auto` | Auto pointer events |
+
+## Float
+
+| Class | Float |
+|-------|-------|
+| `float-start` | Left (LTR) |
+| `float-end` | Right (LTR) |
+| `float-none` | None |
+
+Responsive: `float-{breakpoint}-{start|end|none}`
+
+## Vertical Align
+
+| Class | Alignment |
+|-------|-----------|
+| `align-baseline` | Baseline |
+| `align-top` | Top |
+| `align-middle` | Middle |
+| `align-bottom` | Bottom |
+| `align-text-top` | Text top |
+| `align-text-bottom` | Text bottom |
+
+## Link
+
+### Opacity
+
+| Class | Opacity |
+|-------|---------|
+| `link-opacity-10` | 10% |
+| `link-opacity-25` | 25% |
+| `link-opacity-50` | 50% |
+| `link-opacity-75` | 75% |
+| `link-opacity-100` | 100% |
+| `link-opacity-{value}-hover` | On hover |
+
+### Underline Color
+
+`link-underline-{color}` where color is:
+primary, secondary, success, danger, warning, info, light, dark
+
+### Underline Offset
+
+| Class | Offset |
+|-------|--------|
+| `link-offset-1` | 1 |
+| `link-offset-2` | 2 |
+| `link-offset-3` | 3 |
+
+### Underline Opacity
+
+| Class | Opacity |
+|-------|---------|
+| `link-underline-opacity-0` | 0% |
+| `link-underline-opacity-10` | 10% |
+| `link-underline-opacity-25` | 25% |
+| `link-underline-opacity-50` | 50% |
+| `link-underline-opacity-75` | 75% |
+| `link-underline-opacity-100` | 100% |


### PR DESCRIPTION
## Description

Add three missing Bootstrap 5.3 utility categories to achieve 100% documentation coverage parity with official Bootstrap docs:

- **Float utilities**: `float-start`, `float-end`, `float-none` with responsive variants
- **Vertical align utilities**: `align-baseline`, `align-top`, `align-middle`, `align-bottom`, `align-text-top`, `align-text-bottom`
- **Link utilities** (Bootstrap 5.3+): `link-opacity-*`, `link-underline-*`, `link-offset-*`

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The bootstrap-utilities skill covered 17 out of 20 Bootstrap 5.3 utility categories (85%). This PR adds the 3 missing categories identified during a skill review comparison against official Bootstrap documentation.

Fixes #133

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Run `markdownlint` on modified files - passes
2. Verified all new sections follow existing formatting patterns
3. Verified class names match Bootstrap 5.3.8 documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files - N/A (no HTML files added)
- [ ] I have run `uvx yamllint` on any YAML configuration files - N/A (no YAML files modified)
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [ ] Bootstrap Icons references use version 1.13.x conventions - N/A
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [x] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl)

### Accessibility

- [x] Generated components include proper ARIA attributes where needed
- [x] Color contrast considerations documented where relevant
- [ ] Keyboard navigation supported where applicable - N/A

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [ ] Examples in `examples/` folder are valid HTML/CSS/JS - N/A (no new example files)
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

### Testing

- [ ] I have tested the plugin locally with `claude --plugin-dir .` - Documentation-only changes
- [ ] I have tested the full workflow (if applicable) - N/A
- [ ] I have verified generated Bootstrap code renders correctly - N/A
- [ ] I have tested in a clean repository (not my development repo) - N/A

### Version Management (if applicable)

- [ ] I have updated version in `.claude-plugin/plugin.json` - N/A (minor doc update)
- [ ] I have updated CHANGELOG.md with relevant changes - N/A (minor doc update)

## Additional Notes

The new sections follow the existing documentation patterns:
- SKILL.md: Includes HTML code examples, class reference tables, and usage notes
- utilities-reference.md: Quick-reference tables matching existing format

Priority was marked as low in the issue since:
- Float is somewhat legacy (flexbox preferred)
- Vertical-align is niche (inline elements only)
- Link utilities are a newer 5.3 addition

## Reviewer Notes

**Areas that need special attention**:
- Verify Link utilities coverage matches Bootstrap 5.3.8 (newer feature)
- Check that responsive variant notation is consistent

**Known limitations or trade-offs**:
- None identified

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)