### PR TITLE
docs(bootstrap-customize): add color mode and CSS variable content

### DIFF
--- a/skills/bootstrap-customize/SKILL.md
+++ b/skills/bootstrap-customize/SKILL.md
@@ -35,6 +35,14 @@ Bootstrap's docs call these "CSS variables" (technically CSS custom properties).
 }
 ```
 
+#### CSS Variable Prefix
+
+Customize the `bs-` prefix via the `$prefix` Sass variable to avoid conflicts in projects embedding Bootstrap alongside other frameworks:
+
+```scss
+$prefix: "myapp-"; // Results in --myapp-primary, --myapp-body-bg, etc.
+```
+
 ### 2. Sass Variables (Compile-time)
 
 For comprehensive theming, override Sass variables before importing Bootstrap:
@@ -89,6 +97,24 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
 ```
 
 This generates all utilities: `.bg-custom`, `.text-brand`, `.btn-custom`, etc.
+
+### Adding Colors with Dark Mode Support
+
+Adding a color to `$theme-colors` alone won't generate proper dark mode styles for alerts, badges, and list-groups. Define variants in additional maps:
+
+```scss
+// Light mode variants
+$theme-colors-text: map-merge($theme-colors-text, ("custom": #712cf9));
+$theme-colors-bg-subtle: map-merge($theme-colors-bg-subtle, ("custom": #e1d2fe));
+$theme-colors-border-subtle: map-merge($theme-colors-border-subtle, ("custom": #bfa1fc));
+
+// Dark mode variants
+$theme-colors-text-dark: map-merge($theme-colors-text-dark, ("custom": #e1d2f2));
+$theme-colors-bg-subtle-dark: map-merge($theme-colors-bg-subtle-dark, ("custom": #8951fa));
+$theme-colors-border-subtle-dark: map-merge($theme-colors-border-subtle-dark, ("custom": #e1d2f2));
+```
+
+Without these definitions, components using `*-text-emphasis`, `*-bg-subtle`, and `*-border-subtle` patterns won't display correctly in dark mode.
 
 ### Removing Colors
 
@@ -307,6 +333,18 @@ $enable-container-classes: true;
 $enable-negative-margins: false;
 $enable-dark-mode: true;
 $color-mode-type: data; // 'data' or 'media'
+```
+
+### Focus Ring
+
+Bootstrap 5.3 provides variables to customize `:focus` styles across all components:
+
+```scss
+$focus-ring-width: .25rem;
+$focus-ring-opacity: .25;
+$focus-ring-color: rgba($primary, $focus-ring-opacity);
+$focus-ring-blur: 0;
+$focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color;
 ```
 
 ## Component Customization


### PR DESCRIPTION
## Description

Add three sections to the bootstrap-customize skill to align with official Bootstrap 5.3 documentation:
- **CSS Variable Prefix**: Document `$prefix` Sass variable for custom prefixes
- **Adding Colors with Dark Mode Support**: Explain the additional maps needed for proper dark mode styling
- **Focus Ring**: Document `$focus-ring-*` variables for customizing focus styles

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

The bootstrap-customize skill had content gaps when compared against official Bootstrap 5.3 documentation. This PR addresses three specific gaps identified in the issue:
1. Missing guidance on adding custom colors with proper dark mode support
2. Missing documentation for the CSS variable prefix customization
3. Missing focus ring variables in the Key Sass Variables section

Fixes #135

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Ran `markdownlint skills/bootstrap-customize/SKILL.md` - passed
2. Verified content aligns with Bootstrap 5.3.8 official documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Additional Notes

All three additions were sourced from the official Bootstrap 5.3 customize documentation:
- [Color Modes - Adding Theme Colors](https://getbootstrap.com/docs/5.3/customize/color-modes/#adding-theme-colors)
- [CSS Variables - Prefix](https://getbootstrap.com/docs/5.3/customize/css-variables/#prefix)
- [CSS Variables - Focus Variables](https://getbootstrap.com/docs/5.3/customize/css-variables/#focus-variables)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)