### PR TITLE
docs(bootstrap-forms): add indeterminate, reverse layout, and native haptics

### DIFF
--- a/skills/bootstrap-forms/SKILL.md
+++ b/skills/bootstrap-forms/SKILL.md
@@ -110,6 +110,21 @@ Use `disabled` for fields users cannot interact with at all. Use `readonly` when
 </div>
 ```
 
+### Indeterminate Checkboxes
+
+Use the indeterminate state for checkboxes representing a "partially checked" condition. This is useful for "select all" patterns where some but not all child items are checked. The state must be set via JavaScript—there is no HTML attribute for it.
+
+```html
+<div class="form-check">
+  <input class="form-check-input" type="checkbox" id="checkIndeterminate">
+  <label class="form-check-label" for="checkIndeterminate">Select all items</label>
+</div>
+
+<script>
+  document.getElementById('checkIndeterminate').indeterminate = true;
+</script>
+```
+
 ### Radios
 
 ```html
@@ -138,6 +153,15 @@ Prefer switches over checkboxes for on/off settings that take effect immediately
 </div>
 ```
 
+For iOS 17.4+ Safari, add the `switch` attribute to enable native haptic feedback:
+
+```html
+<div class="form-check form-switch">
+  <input class="form-check-input" type="checkbox" role="switch" id="nativeSwitch" switch>
+  <label class="form-check-label" for="nativeSwitch">Native haptics (iOS 17.4+)</label>
+</div>
+```
+
 ### Inline
 
 ```html
@@ -148,6 +172,22 @@ Prefer switches over checkboxes for on/off settings that take effect immediately
 <div class="form-check form-check-inline">
   <input class="form-check-input" type="checkbox" id="inline2">
   <label class="form-check-label" for="inline2">2</label>
+</div>
+```
+
+### Reverse Layout
+
+Use `.form-check-reverse` to position the input on the opposite side—label first, checkbox/radio second. This creates a right-aligned input style useful for settings interfaces or RTL layouts.
+
+```html
+<div class="form-check form-check-reverse">
+  <input class="form-check-input" type="checkbox" id="reverseCheck">
+  <label class="form-check-label" for="reverseCheck">Reverse checkbox</label>
+</div>
+
+<div class="form-check form-check-reverse">
+  <input class="form-check-input" type="radio" name="reverseRadios" id="reverseRadio1">
+  <label class="form-check-label" for="reverseRadio1">First reverse radio</label>
 </div>
 ```
 

--- a/skills/bootstrap-forms/references/form-reference.md
+++ b/skills/bootstrap-forms/references/form-reference.md
@@ -39,11 +39,23 @@ Complete reference for Bootstrap 5.3 form classes.
 | `.form-check-inline` | Inline checkboxes/radios |
 | `.form-check-reverse` | Reverse order (label first) |
 
+Set indeterminate state via JavaScript for "select all" patterns:
+
+```javascript
+document.getElementById('checkbox').indeterminate = true;
+```
+
 ## Switch Classes
 
 | Class | Description |
 |-------|-------------|
 | `.form-switch` | Add to `.form-check` for switch style |
+
+For iOS 17.4+ Safari, add the `switch` attribute for native haptic feedback:
+
+```html
+<input class="form-check-input" type="checkbox" role="switch" switch>
+```
 
 ## Toggle Button Classes
 


### PR DESCRIPTION
## Description

Enhance checkbox and radio coverage in the bootstrap-forms skill with three features from Bootstrap's official `checks-radios.mdx` documentation:

1. **Indeterminate Checkboxes**: The `:indeterminate` pseudo-class for checkboxes set via JavaScript, useful for "select all" patterns where some but not all items are checked
2. **Reverse Layout**: The `.form-check-reverse` modifier class that puts checkboxes/radios on the opposite side (label first, input second)
3. **Native Switch Haptics**: The `switch` attribute for iOS 17.4+ that enables haptic feedback on toggle switches

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The checkbox/radio section was missing several features documented in Bootstrap's official documentation. This PR adds coverage for these three commonly used patterns.

Fixes #137

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Ran `markdownlint` on modified files - passes
2. Verified HTML examples are valid Bootstrap 5.3.x syntax
3. Confirmed content aligns with official Bootstrap documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes

### Accessibility

- [x] Generated components include proper ARIA attributes where needed

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Additional Notes

Reference: https://getbootstrap.com/docs/5.3/forms/checks-radios/

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)