### PR TITLE
docs(bootstrap-forms): add datalists, range output, and select size

### DIFF
--- a/skills/bootstrap-forms/SKILL.md
+++ b/skills/bootstrap-forms/SKILL.md
@@ -93,7 +93,35 @@ Use `disabled` for fields users cannot interact with at all. Use `readonly` when
 <!-- Sizing -->
 <select class="form-select form-select-lg">...</select>
 <select class="form-select form-select-sm">...</select>
+
+<!-- Visible options with size attribute -->
+<select class="form-select" size="3">
+  <option value="1">One</option>
+  <option value="2">Two</option>
+  <option value="3">Three</option>
+  <option value="4">Four</option>
+</select>
 ```
+
+The `size` attribute displays multiple options without requiring `multiple` selection. Unlike `.form-select-lg` which changes visual scale, `size` controls how many options are visible at once. Use it for small option lists where showing all choices improves usability.
+
+## Datalists
+
+Datalists provide autocomplete suggestions for text inputs. They combine the flexibility of free-text input with the convenience of predefined options.
+
+```html
+<label for="browser" class="form-label">Choose a browser</label>
+<input class="form-control" list="browsers" id="browser" placeholder="Type to search...">
+<datalist id="browsers">
+  <option value="Chrome">
+  <option value="Firefox">
+  <option value="Safari">
+  <option value="Edge">
+  <option value="Opera">
+</datalist>
+```
+
+Connect the input to the datalist using the `list` attribute matching the datalist's `id`. Users can type freely or select from suggestions. Datalist styling is browser-native and varies across browsers—Bootstrap's `.form-control` styles the input, but the dropdown appearance is not customizable.
 
 ## Checkboxes and Radios
 
@@ -244,6 +272,8 @@ Toggle buttons are announced by screen readers as "checked"/"not checked" since 
 
 ## Range
 
+Range inputs provide a slider control. Use `.form-range` for consistent styling across browsers.
+
 ```html
 <label for="range" class="form-label">Range slider</label>
 <input type="range" class="form-range" id="range">
@@ -251,6 +281,21 @@ Toggle buttons are announced by screen readers as "checked"/"not checked" since 
 <!-- With min, max, step -->
 <input type="range" class="form-range" min="0" max="100" step="5">
 ```
+
+### Displaying the Current Value
+
+Use the `<output>` element with JavaScript to show the current range value in real-time:
+
+```html
+<label for="volumeRange" class="form-label">
+  Volume: <output id="volumeValue">50</output>
+</label>
+<input type="range" class="form-range" id="volumeRange"
+       min="0" max="100" value="50"
+       oninput="document.getElementById('volumeValue').textContent = this.value">
+```
+
+The `oninput` event fires as the slider moves, providing immediate feedback. Place the `<output>` element in the label or nearby for clear association. For more complex scenarios, use a separate event listener instead of inline handlers.
 
 ## Input Groups
 


### PR DESCRIPTION
## Description

Add three form control enhancements to the bootstrap-forms skill, aligning with official Bootstrap 5.3 documentation:

1. **Datalists** - Autocomplete suggestions for text inputs
2. **Range Output Value** - Display current range value using `<output>` element with JavaScript
3. **Select Size Attribute** - Show multiple visible options without requiring `multiple` selection

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)

## Motivation and Context

Several useful form control features from the official Bootstrap documentation were missing from the bootstrap-forms skill.

Fixes #138

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: latest
- OS: macOS 26.1

**Test Steps**:
1. Ran `markdownlint skills/bootstrap-forms/SKILL.md` - no errors
2. Verified HTML examples use valid Bootstrap 5.3.x classes
3. Verified examples match official Bootstrap documentation patterns

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files (N/A - no HTML files changed)
- [ ] I have run `uvx yamllint` on any YAML configuration files (N/A - no YAML files changed)
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [ ] Bootstrap Icons references use version 1.13.x conventions (N/A - no icons used)
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [ ] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl) (N/A)

### Accessibility

- [x] Generated components include proper ARIA attributes where needed
- [ ] Color contrast considerations documented where relevant (N/A)
- [ ] Keyboard navigation supported where applicable (N/A)

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [ ] Examples in `examples/` folder are valid HTML/CSS/JS (N/A - no example files changed)
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

### Testing

- [ ] I have tested the plugin locally with `claude --plugin-dir .`
- [x] I have tested the full workflow (if applicable)
- [x] I have verified generated Bootstrap code renders correctly
- [ ] I have tested in a clean repository (not my development repo)

### Version Management (if applicable)

- [ ] I have updated version in `.claude-plugin/plugin.json` (minor doc update, not required)
- [ ] I have updated CHANGELOG.md with relevant changes (minor doc update, not required)

## Additional Notes

Added 45 lines to SKILL.md with explanatory prose and code examples following the existing documentation patterns.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)