### PR TITLE
docs(bootstrap-forms): add input group and validation coverage

### DIFF
--- a/skills/bootstrap-forms/SKILL.md
+++ b/skills/bootstrap-forms/SKILL.md
@@ -348,6 +348,40 @@ Use input groups to visually attach related elements to form controls. Common pa
 <div class="input-group input-group-lg">...</div>
 ```
 
+### Wrapping Behavior
+
+Input groups wrap by default via `flex-wrap: wrap`. To keep all elements on a single line regardless of content width, add `.flex-nowrap`:
+
+```html
+<div class="input-group flex-nowrap">
+  <span class="input-group-text">@</span>
+  <input type="text" class="form-control" placeholder="Username">
+</div>
+```
+
+### Border Radius Limitations
+
+Hidden elements (using `.d-none` or `display: none`) in the first or last position break border-radius styling on adjacent elements. This is a known Bootstrap limitation. Workaround: move hidden elements outside the input group or use visibility utilities instead when the element needs to remain in the DOM.
+
+### Segmented Dropdown Buttons
+
+Use `.dropdown-toggle-split` for split button dropdowns within input groups. This creates a separate dropdown trigger alongside a main action button:
+
+```html
+<div class="input-group">
+  <button type="button" class="btn btn-outline-secondary">Action</button>
+  <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split"
+          data-bs-toggle="dropdown" aria-expanded="false">
+    <span class="visually-hidden">Toggle Dropdown</span>
+  </button>
+  <ul class="dropdown-menu dropdown-menu-end">
+    <li><a class="dropdown-item" href="#">Option 1</a></li>
+    <li><a class="dropdown-item" href="#">Option 2</a></li>
+  </ul>
+  <input type="text" class="form-control" placeholder="Enter value">
+</div>
+```
+
 ## Floating Labels
 
 Use floating labels for a cleaner, more compact form design where labels animate into the input on focus. They work best in simple forms like login or signup. Avoid them when you need help text or complex validation messages alongside inputs.
@@ -368,6 +402,24 @@ Use floating labels for a cleaner, more compact form design where labels animate
   <label for="floatingTextarea">Comments</label>
 </div>
 ```
+
+### Input Groups with Floating Labels and Validation
+
+When combining floating labels with input groups and validation, special structure is required. Place `.form-floating` inside `.input-group`, add `.has-validation` to the input group, and place validation feedback outside `.form-floating` but inside `.input-group`:
+
+```html
+<div class="input-group has-validation">
+  <span class="input-group-text">@</span>
+  <div class="form-floating is-invalid">
+    <input type="text" class="form-control is-invalid" id="floatingUsername"
+           placeholder="Username" required>
+    <label for="floatingUsername">Username</label>
+  </div>
+  <div class="invalid-feedback">Please choose a username.</div>
+</div>
+```
+
+The `.has-validation` class ensures proper border-radius styling when validation feedback is present. Without it, the input group's visual appearance may break with validation states.
 
 ## Form Layout
 
@@ -553,6 +605,21 @@ Mark invalid fields for assistive technology:
 <input type="text" class="form-control is-invalid">
 <div class="invalid-feedback">Please provide a valid value.</div>
 ```
+
+### Validation Tooltips
+
+Use `.valid-tooltip` and `.invalid-tooltip` as alternatives to feedback messages when you want positioned tooltip-style validation. Tooltips appear as floating messages positioned absolutely, requiring the parent element to have `position: relative`:
+
+```html
+<div class="col-md-4 position-relative">
+  <label for="city" class="form-label">City</label>
+  <input type="text" class="form-control is-invalid" id="city" required>
+  <div class="valid-tooltip">Looks good!</div>
+  <div class="invalid-tooltip">Please provide a valid city.</div>
+</div>
+```
+
+Tooltips are useful when feedback messages would disrupt form layout or when you want a more prominent visual indicator. Use them consistently within a form—avoid mixing tooltips and feedback messages.
 
 ## Additional Resources
 

--- a/skills/bootstrap-forms/examples/validation-form.html
+++ b/skills/bootstrap-forms/examples/validation-form.html
@@ -155,6 +155,78 @@
         </div>
       </div>
     </div>
+
+    <!-- Validation Tooltips Example -->
+    <div class="row justify-content-center mt-4">
+      <div class="col-lg-8">
+        <div class="card shadow-sm">
+          <div class="card-header bg-secondary text-white">
+            <h4 class="mb-0">Validation Tooltips Example</h4>
+          </div>
+          <div class="card-body">
+            <p class="text-muted mb-4">
+              Use <code>.valid-tooltip</code> and <code>.invalid-tooltip</code> for positioned
+              validation messages. Parent elements require <code>position-relative</code>.
+            </p>
+            <form class="needs-validation" novalidate>
+              <div class="row g-3">
+                <div class="col-md-4 position-relative">
+                  <label for="tooltipFirstName" class="form-label">First name</label>
+                  <input type="text" class="form-control" id="tooltipFirstName" value="John" required>
+                  <div class="valid-tooltip">Looks good!</div>
+                  <div class="invalid-tooltip">Please enter your first name.</div>
+                </div>
+                <div class="col-md-4 position-relative">
+                  <label for="tooltipLastName" class="form-label">Last name</label>
+                  <input type="text" class="form-control" id="tooltipLastName" value="Doe" required>
+                  <div class="valid-tooltip">Looks good!</div>
+                  <div class="invalid-tooltip">Please enter your last name.</div>
+                </div>
+                <div class="col-md-4 position-relative">
+                  <label for="tooltipCity" class="form-label">City</label>
+                  <input type="text" class="form-control" id="tooltipCity" required>
+                  <div class="valid-tooltip">Looks good!</div>
+                  <div class="invalid-tooltip">Please provide a valid city.</div>
+                </div>
+              </div>
+              <div class="mt-3">
+                <button class="btn btn-secondary" type="submit">Validate with Tooltips</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Input Group with Floating Labels and Validation -->
+    <div class="row justify-content-center mt-4">
+      <div class="col-lg-8">
+        <div class="card shadow-sm">
+          <div class="card-header bg-info text-white">
+            <h4 class="mb-0">Input Group + Floating Labels + Validation</h4>
+          </div>
+          <div class="card-body">
+            <p class="text-muted mb-4">
+              When combining input groups with floating labels and validation, use
+              <code>.has-validation</code> on the input group and place feedback
+              outside <code>.form-floating</code> but inside <code>.input-group</code>.
+            </p>
+            <form class="needs-validation" novalidate>
+              <div class="input-group has-validation mb-3">
+                <span class="input-group-text">@</span>
+                <div class="form-floating">
+                  <input type="text" class="form-control" id="floatingValidationUsername"
+                         placeholder="Username" required>
+                  <label for="floatingValidationUsername">Username</label>
+                </div>
+                <div class="invalid-feedback">Please choose a username.</div>
+              </div>
+              <button class="btn btn-info" type="submit">Check Username</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>

--- a/skills/bootstrap-forms/references/form-reference.md
+++ b/skills/bootstrap-forms/references/form-reference.md
@@ -86,6 +86,10 @@ Outlined variants work with `.btn-outline-*` classes for a lighter appearance.
 | `.input-group-text` | Addon text styling |
 | `.input-group-lg` | Large input group |
 | `.input-group-sm` | Small input group |
+| `.flex-nowrap` | Prevent input group wrapping |
+| `.has-validation` | Enable validation feedback in input groups |
+
+Hidden elements (`.d-none`) in first/last position break border-radius styling—a known Bootstrap limitation.
 
 ## Floating Label Classes
 
@@ -103,8 +107,15 @@ Outlined variants work with `.btn-outline-*` classes for a lighter appearance.
 | `.is-invalid` | Invalid state on input |
 | `.valid-feedback` | Valid feedback message |
 | `.invalid-feedback` | Invalid feedback message |
-| `.valid-tooltip` | Valid tooltip message |
-| `.invalid-tooltip` | Invalid tooltip message |
+| `.valid-tooltip` | Valid tooltip message (positioned) |
+| `.invalid-tooltip` | Invalid tooltip message (positioned) |
+
+### Feedback vs. Tooltips
+
+- **Feedback** (`.valid-feedback`, `.invalid-feedback`): Inline messages that flow with form layout
+- **Tooltips** (`.valid-tooltip`, `.invalid-tooltip`): Positioned absolutely, require parent `position: relative`
+
+Use tooltips when feedback messages would disrupt layout or for a more prominent visual indicator.
 
 ## Form Text
 


### PR DESCRIPTION
## Description

Adds comprehensive documentation for advanced input group and validation patterns from official Bootstrap 5.3 docs to the bootstrap-forms skill.

Reference: https://getbootstrap.com/docs/5.3/forms/input-group/

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README or skill docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Test (adding or updating tests)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Skills (`skills/bootstrap-*`)
- [ ] Agent (`bootstrap-expert`)
- [ ] Commands (`/bootstrap-expert:component`)
- [x] Examples (HTML/CSS/JS samples in `examples/` folders)
- [x] References (skill reference documents in `references/` folders)
- [ ] Documentation (README.md, CONTRIBUTING.md, SECURITY.md)
- [ ] Configuration (plugin.json, .markdownlint.json, .htmlhintrc, .yamllint.yml)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

Several input group and validation features from official Bootstrap docs were missing from the skill documentation. This PR adds comprehensive coverage for edge cases and advanced patterns that developers commonly need.

Fixes #139

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Ran `markdownlint` on all modified markdown files - passed
2. Ran `npx htmlhint` on validation-form.html - passed
3. Verified HTML examples use valid Bootstrap 5.3.8 classes

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [x] I have run `npx htmlhint` on any HTML example files
- [x] I have run `uvx yamllint` on any YAML configuration files
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Bootstrap Icons references use version 1.13.x conventions
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [x] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl)

### Accessibility

- [x] Generated components include proper ARIA attributes where needed
- [x] Color contrast considerations documented where relevant
- [x] Keyboard navigation supported where applicable

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Examples in `examples/` folder are valid HTML/CSS/JS
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

### Testing

- [x] I have tested the plugin locally with `claude --plugin-dir .`
- [x] I have tested the full workflow (if applicable)
- [x] I have verified generated Bootstrap code renders correctly
- [x] I have tested in a clean repository (not my development repo)

## Changes Made

### SKILL.md
- Added "Wrapping Behavior" section (`.flex-nowrap`)
- Added "Border Radius Limitations" section (`.d-none` caveat)
- Added "Segmented Dropdown Buttons" section (`.dropdown-toggle-split`)
- Added "Input Groups with Floating Labels and Validation" section (`.has-validation`)
- Added "Validation Tooltips" section (`.valid-tooltip`/`.invalid-tooltip`)

### form-reference.md
- Added `.flex-nowrap` and `.has-validation` to Input Group Classes table
- Added border radius limitation note
- Expanded Validation Classes with "Feedback vs. Tooltips" explanation

### validation-form.html
- Added "Validation Tooltips Example" section
- Added "Input Group + Floating Labels + Validation" section

## Additional Notes

Part of the bootstrap-forms alignment effort along with #136, #137, #138.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)