### PR TITLE
docs(bootstrap-helpers): add missing position and stretched link details

### DIFF
--- a/plugins/bootstrap-expert/skills/bootstrap-helpers/SKILL.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-helpers/SKILL.md
@@ -163,6 +163,11 @@ Position helpers for common patterns:
 <div class="sticky-xxl-top">Sticky top on xxl+</div>
 
 <div class="sticky-bottom">Sticky bottom</div>
+<div class="sticky-sm-bottom">Sticky bottom on sm+</div>
+<div class="sticky-md-bottom">Sticky bottom on md+</div>
+<div class="sticky-lg-bottom">Sticky bottom on lg+</div>
+<div class="sticky-xl-bottom">Sticky bottom on xl+</div>
+<div class="sticky-xxl-bottom">Sticky bottom on xxl+</div>
 ```
 
 ## Ratio
@@ -270,6 +275,8 @@ Make entire container clickable:
 ```
 
 **Note:** The parent must have `position: relative` (cards have this by default).
+
+**Identifying the containing block:** If the stretched link doesn't work as expected, check for these CSS properties on parent elements which also create containing blocks: `transform`, `perspective`, `filter` (Firefox only), or `will-change` set to `transform` or `perspective`.
 
 ## Text Truncation
 


### PR DESCRIPTION
## Description

Complete bootstrap-helpers skill alignment with official Bootstrap 5.3.8 documentation by adding two missing pieces of information identified in the skill review.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`plugins/bootstrap-expert/skills/bootstrap-*`)

## Motivation and Context

Skill review comparing against official Bootstrap documentation identified two gaps where the skill content didn't fully align with the official docs.

Fixes #141

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS 26.1

**Test Steps**:
1. Ran `markdownlint plugins/bootstrap-expert/skills/bootstrap-helpers/SKILL.md` - no errors
2. Verified changes match official Bootstrap 5.3.8 documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl)

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Changes Made

### 1. Responsive sticky-bottom variants (Position section)

Added the responsive `sticky-{breakpoint}-bottom` variants that were documented for sticky-top but missing for sticky-bottom:
- `.sticky-sm-bottom`
- `.sticky-md-bottom`
- `.sticky-lg-bottom`
- `.sticky-xl-bottom`
- `.sticky-xxl-bottom`

### 2. Containing block identification (Stretched Link section)

Added debugging guidance explaining that stretched links can fail when parent elements have CSS properties that create containing blocks:
- `transform`
- `perspective`
- `filter` (Firefox only)
- `will-change` set to `transform` or `perspective`

## Additional Notes

Low priority documentation improvement - approximately 7 lines added for completeness.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)