### PR TITLE
docs(bootstrap-components): add missing modal features

### DIFF
--- a/plugins/bootstrap-expert/skills/bootstrap-components/references/components-reference.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-components/references/components-reference.md
@@ -179,6 +179,11 @@ Quick reference for all Bootstrap 5.3 component classes.
 | `.modal-lg` | Large modal |
 | `.modal-xl` | Extra large modal |
 | `.modal-fullscreen` | Fullscreen |
+| `.modal-fullscreen-sm-down` | Fullscreen below 576px |
+| `.modal-fullscreen-md-down` | Fullscreen below 768px |
+| `.modal-fullscreen-lg-down` | Fullscreen below 992px |
+| `.modal-fullscreen-xl-down` | Fullscreen below 1200px |
+| `.modal-fullscreen-xxl-down` | Fullscreen below 1400px |
 | `.modal-dialog-centered` | Vertically centered |
 | `.modal-dialog-scrollable` | Scrollable body |
 | `.fade` | Fade animation |

--- a/plugins/bootstrap-expert/skills/bootstrap-components/references/interactive-components.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-components/references/interactive-components.md
@@ -246,6 +246,14 @@ To display dialog boxes, confirmations, or focused content that requires user in
 <div class="modal-dialog modal-lg">...</div>  <!-- 800px -->
 <div class="modal-dialog modal-xl">...</div>  <!-- 1140px -->
 
+<!-- Fullscreen variants -->
+<div class="modal-dialog modal-fullscreen">...</div>           <!-- Always fullscreen -->
+<div class="modal-dialog modal-fullscreen-sm-down">...</div>   <!-- Fullscreen below 576px -->
+<div class="modal-dialog modal-fullscreen-md-down">...</div>   <!-- Fullscreen below 768px -->
+<div class="modal-dialog modal-fullscreen-lg-down">...</div>   <!-- Fullscreen below 992px -->
+<div class="modal-dialog modal-fullscreen-xl-down">...</div>   <!-- Fullscreen below 1200px -->
+<div class="modal-dialog modal-fullscreen-xxl-down">...</div>  <!-- Fullscreen below 1400px -->
+
 <!-- Vertically centered -->
 <div class="modal-dialog modal-dialog-centered">...</div>
 
@@ -268,6 +276,7 @@ const modal = new bootstrap.Modal('#exampleModal', {
 modal.show();
 modal.hide();
 modal.toggle();
+modal.handleUpdate();  // Readjust position after dynamic height change
 
 // Events
 document.getElementById('exampleModal').addEventListener('shown.bs.modal', () => {


### PR DESCRIPTION
## Description

Add missing Bootstrap 5.3.8 modal features to the bootstrap-components skill documentation:

- **Responsive fullscreen variants**: `.modal-fullscreen-sm-down`, `.modal-fullscreen-md-down`, `.modal-fullscreen-lg-down`, `.modal-fullscreen-xl-down`, `.modal-fullscreen-xxl-down`
- **handleUpdate() method**: JavaScript API method for readjusting modal position after dynamic height changes

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The bootstrap-components skill was missing several modal features that are documented in the official Bootstrap 5.3.8 docs. This gap was identified during a skill review.

Fixes #163

## How Has This Been Tested?

**Test Configuration**:
- OS: macOS
- markdownlint: Passed

**Test Steps**:
1. Ran `markdownlint` on modified files - passed
2. Verified HTML code examples follow Bootstrap 5.3.8 conventions
3. Cross-referenced with official Bootstrap documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl)

## Additional Notes

Changes are minimal and focused - only adding the missing modal features without refactoring existing content.

## Reviewer Notes

**Areas that need special attention**:
- Verify responsive breakpoint values match Bootstrap 5.3.8 docs

**Known limitations or trade-offs**:
- None

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)