### PR TITLE
docs(bootstrap-components): note .navbar-light deprecation

### DIFF
--- a/plugins/bootstrap-expert/skills/bootstrap-components/SKILL.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-components/SKILL.md
@@ -102,7 +102,7 @@ Series of content items as lists. Use `.list-group` > `.list-group-item`. Action
 
 ### Navbar
 
-Responsive navigation header. Use `.navbar.navbar-expand-{breakpoint}`. Contains `.navbar-brand`, `.navbar-toggler`, `.navbar-collapse`. Placement: `.fixed-top`, `.fixed-bottom`, `.sticky-top`. Theme: `data-bs-theme="dark"`.
+Responsive navigation header. Use `.navbar.navbar-expand-{breakpoint}`. Contains `.navbar-brand`, `.navbar-toggler`, `.navbar-collapse`. Placement: `.fixed-top`, `.fixed-bottom`, `.sticky-top`. Theme: `data-bs-theme="dark"` (`.navbar-light` deprecated in v5.3).
 
 ### Navs and Tabs
 


### PR DESCRIPTION
## Description

Add deprecation note for `.navbar-light` class in the navbar section of SKILL.md. The class was deprecated in Bootstrap 5.3 in favor of the `data-bs-theme` attribute.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`plugins/bootstrap-expert/skills/bootstrap-*`)

## Motivation and Context

Users migrating from older Bootstrap versions or reading older tutorials may not realize `.navbar-light` is deprecated. This note helps them understand the modern approach.

Fixes #164

## How Has This Been Tested?

**Test Configuration**:
- OS: macOS
- markdownlint: Passed

**Test Steps**:
1. Ran `markdownlint` on SKILL.md - passed
2. Verified change matches Bootstrap 5.3.8 documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation

## Additional Notes

Single-line change adding deprecation note to existing navbar documentation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)