### PR TITLE
docs: use semantic h1 heading for modal titles

### DIFF
--- a/plugins/bootstrap-expert/skills/bootstrap-components/examples/modal-patterns.html
+++ b/plugins/bootstrap-expert/skills/bootstrap-components/examples/modal-patterns.html
@@ -21,7 +21,7 @@
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title" id="basicModalLabel">Basic Modal</h5>
+              <h1 class="modal-title fs-5" id="basicModalLabel">Basic Modal</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
@@ -47,7 +47,7 @@
         <div class="modal-dialog modal-dialog-scrollable">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Scrollable Modal</h5>
+              <h1 class="modal-title fs-5">Scrollable Modal</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
@@ -74,7 +74,7 @@
         <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Centered Modal</h5>
+              <h1 class="modal-title fs-5">Centered Modal</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
@@ -99,7 +99,7 @@
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Static Backdrop</h5>
+              <h1 class="modal-title fs-5">Static Backdrop</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
@@ -129,7 +129,7 @@
         <div class="modal-dialog modal-sm">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Small Modal</h5>
+              <h1 class="modal-title fs-5">Small Modal</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">Small modal content.</div>
@@ -142,7 +142,7 @@
         <div class="modal-dialog modal-lg">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Large Modal</h5>
+              <h1 class="modal-title fs-5">Large Modal</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">Large modal content.</div>
@@ -155,7 +155,7 @@
         <div class="modal-dialog modal-xl">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Extra Large Modal</h5>
+              <h1 class="modal-title fs-5">Extra Large Modal</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">Extra large modal content.</div>
@@ -168,7 +168,7 @@
         <div class="modal-dialog modal-fullscreen">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Fullscreen Modal</h5>
+              <h1 class="modal-title fs-5">Fullscreen Modal</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">Fullscreen modal content.</div>
@@ -188,9 +188,9 @@
         <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
             <div class="modal-header border-0">
-              <h5 class="modal-title text-danger">
+              <h1 class="modal-title fs-5 text-danger">
                 <i class="bi bi-exclamation-triangle-fill me-2"></i>Confirm Delete
-              </h5>
+              </h1>
             </div>
             <div class="modal-body">
               <p>Are you sure you want to delete this item? This action cannot be undone.</p>
@@ -215,7 +215,7 @@
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Add New Item</h5>
+              <h1 class="modal-title fs-5">Add New Item</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <form>

--- a/plugins/bootstrap-expert/skills/bootstrap-components/references/static-components.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-components/references/static-components.md
@@ -212,7 +212,7 @@ To create a generic dismiss button for alerts, modals, toasts, and other dismiss
 
 <!-- In modal header -->
 <div class="modal-header">
-  <h5 class="modal-title">Modal title</h5>
+  <h1 class="modal-title fs-5">Modal title</h1>
   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 </div>
 

--- a/plugins/bootstrap-expert/skills/bootstrap-overview/examples/rails-turbo-modal.html.erb
+++ b/plugins/bootstrap-expert/skills/bootstrap-overview/examples/rails-turbo-modal.html.erb
@@ -68,9 +68,9 @@
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="taskModalLabel">
+          <h1 class="modal-title fs-5" id="taskModalLabel">
             <i class="bi bi-plus-circle me-2"></i>New Task
-          </h5>
+          </h1>
           <button type="button"
                   class="btn-close"
                   data-bs-dismiss="modal"

--- a/plugins/bootstrap-expert/skills/bootstrap-overview/references/vite-setup.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-overview/references/vite-setup.md
@@ -124,7 +124,7 @@ export default defineConfig({
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title">Modal Title</h5>
+              <h1 class="modal-title fs-5">Modal Title</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">


### PR DESCRIPTION
## Description

Update modal examples to use `<h1 class="modal-title fs-5">` instead of `<h5 class="modal-title">` per Bootstrap 5.3 documentation recommendation.

Per the official Bootstrap docs:
> Structurally, however, a modal dialog represents its own separate document/context, so the `.modal-title` should ideally be an `<h1>`. If necessary, you can use the font size utilities to control the heading's appearance.

The `bootstrap-components` SKILL.md already documents this best practice, but the example files didn't follow it.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`plugins/bootstrap-expert/skills/bootstrap-*`)
- [x] Examples (HTML/CSS/JS/ERB samples in `examples/` folders)
- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

Aligns example code with documented best practices for semantic HTML in modals.

Fixes #169

## How Has This Been Tested?

**Test Configuration**:
- OS: macOS
- Linting tools: markdownlint, htmlhint, erb_lint

**Test Steps**:
1. Ran `markdownlint` on updated markdown files - passed
2. Ran `npx htmlhint` on updated HTML files - passed  
3. Ran `erb_lint` on updated ERB files - passed
4. Verified all `h1` tags are properly closed

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [x] I have run `npx htmlhint` on any HTML example files
- [x] I have run `erb_lint --lint-all` on any ERB example files
- [x] I have verified special HTML elements are properly closed

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes

### Accessibility

- [x] Generated components include proper ARIA attributes where needed

## Files Changed

| File | Changes |
|------|---------|
| `plugins/bootstrap-expert/skills/bootstrap-components/examples/modal-patterns.html` | Updated 10 modal titles from `<h5>` to `<h1 class="fs-5">` |
| `plugins/bootstrap-expert/skills/bootstrap-components/references/static-components.md` | Updated 1 modal example |
| `plugins/bootstrap-expert/skills/bootstrap-overview/references/vite-setup.md` | Updated 1 modal example |
| `plugins/bootstrap-expert/skills/bootstrap-overview/examples/rails-turbo-modal.html.erb` | Updated 1 modal title |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)