### PR TITLE
docs: use data-bs-title and document tabindex for tooltips

### DIFF
--- a/plugins/bootstrap-expert/skills/bootstrap-components/references/interactive-components.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-components/references/interactive-components.md
@@ -574,34 +574,38 @@ To add hover hints that provide brief descriptions, use the tooltip component. T
 ```html
 <!-- Tooltip triggers -->
 <button type="button" class="btn btn-secondary"
-  data-bs-toggle="tooltip" data-bs-placement="top" title="Tooltip on top">
+  data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Tooltip on top">
   Tooltip on top
 </button>
 <button type="button" class="btn btn-secondary"
-  data-bs-toggle="tooltip" data-bs-placement="right" title="Tooltip on right">
+  data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Tooltip on right">
   Tooltip on right
 </button>
 <button type="button" class="btn btn-secondary"
-  data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tooltip on bottom">
+  data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Tooltip on bottom">
   Tooltip on bottom
 </button>
 <button type="button" class="btn btn-secondary"
-  data-bs-toggle="tooltip" data-bs-placement="left" title="Tooltip on left">
+  data-bs-toggle="tooltip" data-bs-placement="left" data-bs-title="Tooltip on left">
   Tooltip on left
 </button>
 
 <!-- HTML content in tooltip -->
 <button type="button" class="btn btn-secondary"
   data-bs-toggle="tooltip" data-bs-html="true"
-  title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">
+  data-bs-title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">
   Tooltip with HTML
 </button>
 
-<!-- Tooltip on disabled button (requires wrapper) -->
-<span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="Disabled tooltip">
+<!-- Tooltip on disabled button (requires wrapper with tabindex for keyboard accessibility) -->
+<span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-title="Disabled tooltip">
   <button class="btn btn-primary" type="button" disabled>Disabled button</button>
 </span>
 ```
+
+**Note:** Use `data-bs-title` instead of `title` when possible. Both attributes work, but `data-bs-title` is the modern approach that avoids conflicts with the browser's native tooltip behavior.
+
+**Disabled elements:** The `tabindex="0"` on the wrapper is essential—without it, keyboard users cannot focus the element to trigger the tooltip.
 
 **JavaScript initialization (required):**
 


### PR DESCRIPTION
## Description

Update tooltip documentation to align with Bootstrap 5.3 best practices:

- Replace `title` attribute with `data-bs-title` in all tooltip examples
- Add note explaining `data-bs-title` is preferred to avoid conflicts with browser's native tooltip behavior
- Add note explaining `tabindex="0"` is essential on disabled element wrappers for keyboard accessibility

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The tooltip documentation was using the legacy `title` attribute instead of the modern `data-bs-title` approach recommended in Bootstrap 5.3 docs. Additionally, while the disabled element wrapper example already had `tabindex="0"`, there was no explanation of why it's required for keyboard accessibility.

Fixes #170

## How Has This Been Tested?

**Test Configuration**:

- Claude Code version: Latest
- OS: macOS 26.1

**Test Steps**:

1. Verified markdown passes linting with `markdownlint`
2. Reviewed changes against Bootstrap 5.3 official documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have updated YAML frontmatter where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues
- [ ] I have run `npx htmlhint` on any HTML example files (N/A - inline HTML in markdown)
- [ ] I have run `erb_lint --lint-all` on any ERB example files (N/A)
- [ ] I have run `uvx yamllint` on any YAML configuration files (N/A)
- [x] I have verified special HTML elements are properly closed (`<p>`, `<img>`, `<example>`, `<commentary>`)

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation
- [ ] Bootstrap Icons references use version 1.13.x conventions (N/A)
- [x] Generated HTML/CSS uses valid Bootstrap 5.3.x classes
- [ ] Responsive breakpoints use correct Bootstrap values (sm/md/lg/xl/xxl) (N/A)

### Accessibility

- [x] Generated components include proper ARIA attributes where needed
- [ ] Color contrast considerations documented where relevant (N/A)
- [x] Keyboard navigation supported where applicable

### Testing

- [ ] I have tested the plugin locally with `claude --plugin-dir .` (documentation-only change)
- [ ] I have tested the full workflow (if applicable) (N/A)
- [ ] I have verified generated Bootstrap code renders correctly (N/A)
- [ ] I have tested in a clean repository (not my development repo) (N/A)

### Version Management (if applicable)

- [ ] I have updated version in `plugins/bootstrap-expert/.claude-plugin/plugin.json` (minor doc fix)
- [ ] I have updated CHANGELOG.md with relevant changes (minor doc fix)

## Additional Notes

This PR addresses both improvements requested in #170. Related to #169 (both from the same skill review).

## Reviewer Notes

**Areas that need special attention**:
- Verify the notes are clear and helpful for users new to Bootstrap tooltips

**Known limitations or trade-offs**:
- None

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)