### PR TITLE
docs(bootstrap-components): add Popper.js dependency and tabindex guidance

### DIFF
--- a/plugins/bootstrap-expert/skills/bootstrap-components/SKILL.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-components/SKILL.md
@@ -62,7 +62,9 @@ Auto-update navigation based on scroll position. Use `data-bs-spy="scroll"` on s
 
 ### Tooltips
 
-**Requires JS init.** Hover hints for brief descriptions. Use `data-bs-toggle="tooltip"` with `title` attribute. Initialize with `new bootstrap.Tooltip(el)` or batch initialize all: `document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el))`. Placements: top, right, bottom, left.
+**Requires JS init.** Hover hints for brief descriptions. Use `data-bs-toggle="tooltip"` with `title` attribute. Initialize with `new bootstrap.Tooltip(el)` or batch initialize all: `document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el))`. Placements: top, right, bottom, left. Tooltips on disabled buttons require a wrapper `<span>` or `<div>` with `tabindex="0"` for keyboard accessibility.
+
+**Note:** Tooltips and popovers require Popper.js for positioning. Use `bootstrap.bundle.js` (includes Popper) or include Popper separately before `bootstrap.js`.
 
 ## Static Components
 


### PR DESCRIPTION
## Description

Add two documentation improvements to the bootstrap-components skill's Tooltips section that address common "why isn't my tooltip working?" troubleshooting scenarios.

Changes:
1. **Popper.js dependency note**: Users must include Popper.js (via `bootstrap.bundle.js` or separately) for tooltips/popovers to work
2. **`tabindex="0"` guidance**: Essential for keyboard accessibility when wrapping disabled buttons with tooltips

These gaps were identified during a skill review comparing against official Bootstrap 5.3 documentation.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Skills (`plugins/bootstrap-expert/skills/bootstrap-*`)

## Motivation and Context

During a `/skill-review bootstrap-components` comparing against official Bootstrap documentation, two documentation gaps were identified:

1. The official Bootstrap docs prominently state tooltips/popovers "rely on the third party library Popper for positioning" - without this, they completely fail
2. The official docs emphasize `tabindex="0"` on wrapper elements is "essential" for keyboard users with disabled button tooltips

Both address common user pain points that cause tooltips to silently fail.

Fixes #173

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: 1.0.40
- OS: macOS

**Test Steps**:
1. Verified markdownlint passes with no errors
2. Reviewed changes align with official Bootstrap 5.3 documentation
3. Confirmed SKILL.md word count remains within 1,000-2,200 target

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation

### Accessibility

- [x] Keyboard navigation supported where applicable

### Component-Specific Checks

<details>
<summary><strong>Skills</strong> (click to expand)</summary>

- [x] SKILL.md is 1,000-2,200 words (progressive disclosure)
- [x] Content aligns with official Bootstrap documentation
- [x] Skill demonstrates Bootstrap best practices

</details>

## Additional Notes

Both improvements were suggested with specific wording in issue #173. The implementation adds:
- `tabindex="0"` guidance directly to the Tooltips paragraph
- A separate "Note" paragraph about Popper.js dependency

This keeps the documentation concise while addressing critical troubleshooting information.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)