### PR TITLE
docs(bootstrap-customize): add color-mode() mixin and rename color-scheme section

### DIFF
--- a/plugins/bootstrap-expert/skills/bootstrap-customize/references/sass-functions-mixins.md
+++ b/plugins/bootstrap-expert/skills/bootstrap-customize/references/sass-functions-mixins.md
@@ -254,9 +254,51 @@ Target a range spanning multiple breakpoints.
 
 ## Color Mode Mixin
 
+### color-mode($mode)
+
+Applies styles based on the current color mode setting. Output depends on `$color-mode-type`:
+
+- When `data` (default): Outputs `[data-bs-theme="X"]` selector
+- When `media-query`: Outputs `@media (prefers-color-scheme: X)`
+
+```scss
+@include color-mode(dark) {
+  .element {
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+  }
+}
+```
+
+**With `$color-mode-type: data` (default), compiles to:**
+
+```css
+[data-bs-theme=dark] .element {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+```
+
+**With `$color-mode-type: media-query`, compiles to:**
+
+```css
+@media (prefers-color-scheme: dark) {
+  .element {
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+  }
+}
+```
+
+Use `color-mode()` when you want styles to respect the project's `$color-mode-type` configuration.
+
+---
+
+## Color Scheme Mixin
+
 ### color-scheme($name)
 
-Shorthand for `prefers-color-scheme` media query.
+Direct shorthand for `prefers-color-scheme` media query. Unlike `color-mode()`, this always outputs a media query regardless of `$color-mode-type`.
 
 ```scss
 .adaptive-element {


### PR DESCRIPTION
## Description

Add documentation for the `color-mode()` mixin and correctly rename the existing "Color Mode Mixin" section to "Color Scheme Mixin" to match Bootstrap's official documentation terminology.

Per Bootstrap's official docs, these are two distinct mixins:
- `color-mode($mode)` - Respects `$color-mode-type` setting, outputs either `[data-bs-theme=X]` selector or `@media (prefers-color-scheme)` 
- `color-scheme($name)` - Direct shorthand for `@media (prefers-color-scheme)` only

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] References (skill reference documents in `references/` folders)

## Motivation and Context

The reference file had a section titled "Color Mode Mixin" but actually documented `color-scheme()`. This was misleading and didn't document the primary `color-mode()` mixin that most users should be using.

Fixes #175

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Ran `markdownlint` on the edited file - passed with no errors
2. Verified content aligns with Bootstrap 5.3 official documentation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint` and fixed all issues

### Bootstrap Compatibility

- [x] Changes align with Bootstrap 5.3.8 documentation

## Additional Notes

References used:
- https://getbootstrap.com/docs/5.3/customize/sass/#color-schemes
- https://getbootstrap.com/docs/5.3/customize/color-modes/#building-with-sass

## Reviewer Notes

**Areas that need special attention**:
- Verify the `color-mode()` documentation accurately reflects Bootstrap's behavior

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)